### PR TITLE
Fix drawLine() being drawn at incorrect y when dashWidth is non-zero

### DIFF
--- a/main/display/shapes.c
+++ b/main/display/shapes.c
@@ -81,7 +81,7 @@ static void drawLineInner(int x0, int y0, int x1, int y1, paletteColor_t col, in
         {
             if (dashDraw)
             {
-                TURBO_SET_PIXEL_BOUNDS(xOrigin + x0 * xScale, yOrigin + y0 * yOrigin, col);
+                TURBO_SET_PIXEL_BOUNDS(xOrigin + x0 * xScale, yOrigin + y0 * yScale, col);
             }
             dashCnt++;
             if (dashWidth == dashCnt)


### PR DESCRIPTION
### Description

<!--- What was added and/or fixed in this pull request? -->

This pull request fixes a bug in `drawLineInner()` that causes it to scale dashed lines by `yOffset` rather than `yScale`. In the case of a call to the regular unscaled `drawLine()` function , this means that the line's endpoint is always drawn at `y=0`.

### Test Instructions

<!--- How was this tested? -->

To test, try drawing a dashed and regular line and seeing that they both draw in the correct place.

### Ticket Links

<!--- Link any tickets that are completed in this pull request. -->

### Readiness Checklist
- [x] I have run `make format` to format the changes
- [x] I have compiled the firmware and the changes have no warnings
- [x] I have compiled the emulator and the changes have no warnings
- [x] I have run `make cppcheck` and checked that `cppcheck_result.txt` has no warnings for the changes
- [x] I have added doxygen comments to any code used by more than one Swadge mode. This includes `/*! \file` comments with Design Philosophy, Usage, and Example sections for new headers.
- [x] I have run `make docs` and checked that `doxy_warnings.txt` has no warnings for the new code
