### PR TITLE
Allow fonter to use non-integer-font-heights.

### DIFF
--- a/tools/font_maker/src/fontmaker.c
+++ b/tools/font_maker/src/fontmaker.c
@@ -92,7 +92,7 @@ int main(int32_t argc, char** argv)
 
     // Pick out the arguments
     char* fontFile     = argv[1];
-    int32_t fontSizePx = atoi(argv[2]);
+    float fontSizePx = atof(argv[2]);
 
     // Validate size
     if (0 == fontSizePx)


### PR DESCRIPTION
It allows you to have many more options when selecting a font size.