### PR TITLE
Mapped menu items

### DIFF
--- a/main/menu/menu.c
+++ b/main/menu/menu.c
@@ -379,6 +379,8 @@ void removeSettingsItemFromMenu(menu_t* menu, const char* label)
  * selected label and setting value as the arguments.
  *
  * @param menu The menu to add a settings options item to
+ * @param settingLabel The overall label for this setting. This is what will be
+ *                     passed to the callback when the selected option changes.
  * @param optionLabels All of the labels for each option. The underlying memory
  *                     isn't copied, so these strings must persist for the
  *                     lifetime of the menu.
@@ -390,10 +392,12 @@ void removeSettingsItemFromMenu(menu_t* menu, const char* label)
  * @param currentValue The current value of the setting. Must be one of the values
  *                     in \c optionValues.
  */
-void addSettingsOptionsItemToMenu(menu_t* menu, const char* const* optionLabels, const int32_t* optionValues,
-                                  uint8_t numOptions, const settingParam_t* bounds, int32_t currentValue)
+void addSettingsOptionsItemToMenu(menu_t* menu, const char* settingLabel, const char* const* optionLabels,
+                                  const int32_t* optionValues, uint8_t numOptions, const settingParam_t* bounds,
+                                  int32_t currentValue)
 {
     menuItem_t* newItem  = calloc(1, sizeof(menuItem_t));
+    newItem->label       = settingLabel;
     newItem->options     = optionLabels;
     newItem->settingVals = optionValues;
     newItem->numOptions  = numOptions;
@@ -517,13 +521,16 @@ menu_t* menuButton(menu_t* menu, buttonEvt_t btn)
                         item->currentOpt--;
                     }
 
+                    // Call the callback, not selected
                     if (item->settingVals)
                     {
                         item->currentSetting = item->settingVals[item->currentOpt];
+                        menu->cbFunc(item->label, false, item->currentSetting);
                     }
-
-                    // Call the callback, not selected
-                    menu->cbFunc(item->options[item->currentOpt], false, item->settingVals ? item->currentSetting : 0);
+                    else
+                    {
+                        menu->cbFunc(item->options[item->currentOpt], false, 0);
+                    }
                 }
                 else if (item->minSetting != item->maxSetting)
                 {
@@ -552,13 +559,16 @@ menu_t* menuButton(menu_t* menu, buttonEvt_t btn)
                         item->currentOpt++;
                     }
 
+                    // Call the callback, not selected
                     if (item->settingVals)
                     {
                         item->currentSetting = item->settingVals[item->currentOpt];
+                        menu->cbFunc(item->label, false, item->currentSetting);
                     }
-
-                    // Call the callback, not selected
-                    menu->cbFunc(item->options[item->currentOpt], false, item->settingVals ? item->currentSetting : 0);
+                    else
+                    {
+                        menu->cbFunc(item->options[item->currentOpt], false, 0);
+                    }
                 }
                 else if (item->minSetting != item->maxSetting)
                 {

--- a/main/menu/menu.c
+++ b/main/menu/menu.c
@@ -433,7 +433,7 @@ void addSettingsOptionsItemToMenu(menu_t* menu, const char* const* optionLabels,
  * @param menu The menu to remove a multi item from
  * @param optionLabels The list of option labels to remove
  */
-void removeSettingsOptionsItemFrommenu(menu_t* menu, const char* const* optionLabels)
+void removeSettingsOptionsItemFromMenu(menu_t* menu, const char* const* optionLabels)
 {
     node_t* listNode = menu->items->first;
     while (NULL != listNode)

--- a/main/menu/menu.c
+++ b/main/menu/menu.c
@@ -390,7 +390,8 @@ void removeSettingsItemFromMenu(menu_t* menu, const char* label)
  * @param currentValue The current value of the setting. Must be one of the values
  *                     in \c optionValues.
  */
-void addSettingsOptionsItemToMenu(menu_t* menu, const char* const* optionLabels, const int32_t* optionValues, uint8_t numOptions, const settingParam_t* bounds, int32_t currentValue)
+void addSettingsOptionsItemToMenu(menu_t* menu, const char* const* optionLabels, const int32_t* optionValues,
+                                  uint8_t numOptions, const settingParam_t* bounds, int32_t currentValue)
 {
     menuItem_t* newItem  = calloc(1, sizeof(menuItem_t));
     newItem->options     = optionLabels;
@@ -400,7 +401,7 @@ void addSettingsOptionsItemToMenu(menu_t* menu, const char* const* optionLabels,
     newItem->maxSetting  = bounds->max;
 
     // Set the current option to the first in case we can't find it
-    newItem->currentOpt  = 0;
+    newItem->currentOpt = 0;
 
     // Find the matching element in optionValues
     // We're doing this here because pretty much it's gonna happen somewhere.
@@ -424,7 +425,6 @@ void addSettingsOptionsItemToMenu(menu_t* menu, const char* const* optionLabels,
         menu->currentItem = menu->items->first;
     }
 }
-
 
 /**
  * @brief Remove a settings options item entry from the menu. This item is removed by

--- a/main/menu/menu.c
+++ b/main/menu/menu.c
@@ -517,11 +517,11 @@ menu_t* menuButton(menu_t* menu, buttonEvt_t btn)
                 // Scroll options to the left, if applicable
                 if (item->options)
                 {
-                    if (0 == item->currentOpt)
+                    if (0 == item->currentOpt && !item->settingVals)
                     {
                         item->currentOpt = item->numOptions - 1;
                     }
-                    else
+                    else if (item->currentOpt > 0)
                     {
                         item->currentOpt--;
                     }
@@ -555,11 +555,11 @@ menu_t* menuButton(menu_t* menu, buttonEvt_t btn)
                 // Scroll options to the right, if applicable
                 if (item->options)
                 {
-                    if (item->numOptions - 1 == item->currentOpt)
+                    if (item->numOptions - 1 == item->currentOpt && !item->settingVals)
                     {
                         item->currentOpt = 0;
                     }
-                    else
+                    else if (item->currentOpt + 1 < item->numOptions)
                     {
                         item->currentOpt++;
                     }

--- a/main/menu/menu.c
+++ b/main/menu/menu.c
@@ -373,6 +373,94 @@ void removeSettingsItemFromMenu(menu_t* menu, const char* label)
 }
 
 /**
+ * Adds a settings item entry to the menu with a specific list of options. The
+ * enry will be left-right scrollable. The ::menuCb callback will be called
+ * each time the setting-options item scrolls or is selected with the newly
+ * selected label and setting value as the arguments.
+ *
+ * @param menu The menu to add a settings options item to
+ * @param optionLabels All of the labels for each option. The underlying memory
+ *                     isn't copied, so these strings must persist for the
+ *                     lifetime of the menu.
+ * @param optionValues The corresponding settings values for each option. The
+ *                     underlying memory isn't copied, so these strings must
+ *                     persist for the lifetime of the menu. These values
+ * @param numOptions The number of options and labels for this settings item.
+ * @param bounds The bounds for this setting
+ * @param currentValue The current value of the setting. Must be one of the values
+ *                     in \c optionValues.
+ */
+void addSettingsOptionsItemToMenu(menu_t* menu, const char* const* optionLabels, const int32_t* optionValues, uint8_t numOptions, const settingParam_t* bounds, int32_t currentValue)
+{
+    menuItem_t* newItem  = calloc(1, sizeof(menuItem_t));
+    newItem->options     = optionLabels;
+    newItem->settingVals = optionValues;
+    newItem->numOptions  = numOptions;
+    newItem->minSetting  = bounds->min;
+    newItem->maxSetting  = bounds->max;
+
+    // Set the current option to the first in case we can't find it
+    newItem->currentOpt  = 0;
+
+    // Find the matching element in optionValues
+    // We're doing this here because pretty much it's gonna happen somewhere.
+    // Doing it this way makes it super easy to use anywhere and we don't need
+    // to worry that much if the value happened to be changed to an invalid
+    // option somewhere else -- we'll just reset it if it's changed.
+    for (uint8_t i = 0; i < numOptions; i++)
+    {
+        if (currentValue == newItem->settingVals[i])
+        {
+            newItem->currentOpt = i;
+            break;
+        }
+    }
+
+    push(menu->items, newItem);
+
+    // If this is the first item, set it as the current
+    if (1 == menu->items->length)
+    {
+        menu->currentItem = menu->items->first;
+    }
+}
+
+
+/**
+ * @brief Remove a settings options item entry from the menu. This item is removed by
+ * pointer, not by doing any string comparisons
+ *
+ * @param menu The menu to remove a multi item from
+ * @param optionLabels The list of option labels to remove
+ */
+void removeSettingsOptionsItemFrommenu(menu_t* menu, const char* const* optionLabels)
+{
+    node_t* listNode = menu->items->first;
+    while (NULL != listNode)
+    {
+        menuItem_t* item = listNode->val;
+        if (item->options == optionLabels)
+        {
+            removeEntry(menu->items, listNode);
+            if (menu->currentItem == listNode)
+            {
+                if (NULL != listNode->next)
+                {
+                    menu->currentItem = listNode->next;
+                }
+                else
+                {
+                    menu->currentItem = listNode->prev;
+                }
+            }
+            free(item);
+            return;
+        }
+        listNode = listNode->next;
+    }
+}
+
+/**
  * This must be called to pass button event from the Swadge mode to the menu.
  * If a button is passed here, it should not be handled anywhere else
  *
@@ -429,8 +517,13 @@ menu_t* menuButton(menu_t* menu, buttonEvt_t btn)
                         item->currentOpt--;
                     }
 
+                    if (item->settingVals)
+                    {
+                        item->currentSetting = item->settingVals[item->currentOpt];
+                    }
+
                     // Call the callback, not selected
-                    menu->cbFunc(item->options[item->currentOpt], false, 0);
+                    menu->cbFunc(item->options[item->currentOpt], false, item->settingVals ? item->currentSetting : 0);
                 }
                 else if (item->minSetting != item->maxSetting)
                 {
@@ -459,8 +552,13 @@ menu_t* menuButton(menu_t* menu, buttonEvt_t btn)
                         item->currentOpt++;
                     }
 
+                    if (item->settingVals)
+                    {
+                        item->currentSetting = item->settingVals[item->currentOpt];
+                    }
+
                     // Call the callback, not selected
-                    menu->cbFunc(item->options[item->currentOpt], false, 0);
+                    menu->cbFunc(item->options[item->currentOpt], false, item->settingVals ? item->currentSetting : 0);
                 }
                 else if (item->minSetting != item->maxSetting)
                 {
@@ -491,6 +589,10 @@ menu_t* menuButton(menu_t* menu, buttonEvt_t btn)
                     // Reset the current item when leaving a submenu
                     menu->currentItem = menu->items->first;
                     return menu->parentMenu;
+                }
+                else if (item->settingVals)
+                {
+                    menu->cbFunc(item->options[item->currentOpt], true, item->settingVals[item->currentOpt]);
                 }
                 else if (item->minSetting != item->maxSetting)
                 {

--- a/main/menu/menu.c
+++ b/main/menu/menu.c
@@ -380,13 +380,18 @@ void removeSettingsItemFromMenu(menu_t* menu, const char* label)
  *
  * @param menu The menu to add a settings options item to
  * @param settingLabel The overall label for this setting. This is what will be
- *                     passed to the callback when the selected option changes.
+ *                     passed to the callback when the selected option changes,
+ *                     and this value will be rendered preceding the selected
+ *                     option's label.
  * @param optionLabels All of the labels for each option. The underlying memory
  *                     isn't copied, so these strings must persist for the
- *                     lifetime of the menu.
+ *                     lifetime of the menu. The label value for the selected
+ *                     option will be rendered following the settingLabel.
  * @param optionValues The corresponding settings values for each option. The
- *                     underlying memory isn't copied, so these strings must
- *                     persist for the lifetime of the menu. These values
+ *                     underlying memory isn't copied, so this array must
+ *                     persist for the lifetime of the menu. These values will
+ *                     not be rendered, but will be passed to the callback as
+ *                     the \c value when the selected option is changed.
  * @param numOptions The number of options and labels for this settings item.
  * @param bounds The bounds for this setting
  * @param currentValue The current value of the setting. Must be one of the values

--- a/main/menu/menu.h
+++ b/main/menu/menu.h
@@ -54,6 +54,7 @@
  * static const char opt4[]            = "opt4";
  * static const char* const demoOpts[] = {opt1, opt2, opt3, opt4};
  *
+ * static const char optionSettingLabel[] = "OptSetting: "
  * static const char* const optionSettingLabels = {"Off", "30 Seconds", "5 Minutes"};
  * static const uint32_t optionSettingValues = {0, 30, 300};
  *
@@ -91,8 +92,8 @@
  * addSingleItemToMenu(menu, demoMenu5);
  * addSingleItemToMenu(menu, demoMenu6);
  * addSettingsItemToMenu(menu, demoSettingLabel, getTftBrightnessSettingBounds(), getTftBrightnessSetting());
- * addSettingsOptionsItemToMenu(menu, optionSettingLabels, optionSettingValues, ARRAY_SIZE(optionSettingValues),
- *                              getScreensaverTimeSettingBounds(), 0);
+ * addSettingsOptionsItemToMenu(menu, optionSettingLabel, optionSettingLabels, optionSettingValues,
+ *                              ARRAY_SIZE(optionSettingValues), getScreensaverTimeSettingBounds(), 0);
  *
  * // Load a font
  * font_t logbook;
@@ -193,8 +194,9 @@ void addMultiItemToMenu(menu_t* menu, const char* const* labels, uint8_t numLabe
 void removeMultiItemFromMenu(menu_t* menu, const char* const* labels);
 void addSettingsItemToMenu(menu_t* menu, const char* label, const settingParam_t* bounds, int32_t val);
 void removeSettingsItemFromMenu(menu_t* menu, const char* label);
-void addSettingsOptionsItemToMenu(menu_t* menu, const char* const* optionLabels, const int32_t* optionValues,
-                                  uint8_t numOptions, const settingParam_t* bounds, int32_t currentOption);
+void addSettingsOptionsItemToMenu(menu_t* menu, const char* settingLabel, const char* const* optionLabels,
+                                  const int32_t* optionValues, uint8_t numOptions, const settingParam_t* bounds,
+                                  int32_t currentOption);
 void removeSettingsOptionsItemFromMenu(menu_t* menu, const char* const* optionLabels);
 menu_t* menuButton(menu_t* menu, buttonEvt_t btn) __attribute__((warn_unused_result));
 

--- a/main/menu/menu.h
+++ b/main/menu/menu.h
@@ -54,6 +54,9 @@
  * static const char opt4[]            = "opt4";
  * static const char* const demoOpts[] = {opt1, opt2, opt3, opt4};
  *
+ * static const char* const optionSettingLabels = {"Off", "30 Seconds", "5 Minutes"};
+ * static const uint32_t optionSettingValues = {0, 30, 300};
+ *
  * static const char demoSettingLabel[] = "Setting";
  * \endcode
  *
@@ -88,6 +91,8 @@
  * addSingleItemToMenu(menu, demoMenu5);
  * addSingleItemToMenu(menu, demoMenu6);
  * addSettingsItemToMenu(menu, demoSettingLabel, getTftBrightnessSettingBounds(), getTftBrightnessSetting());
+ * addSettingsOptionsItemToMenu(menu, optionSettingLabels, optionSettingValues, ARRAY_SIZE(optionSettingValues),
+ *                              getScreensaverTimeSettingBounds(), 0);
  *
  * // Load a font
  * font_t logbook;
@@ -112,9 +117,9 @@
  *
  * Receive menu callbacks:
  * \code{.c}
- * static void demoMenuCb(const char* label, bool selected)
+ * static void demoMenuCb(const char* label, bool selected, uint32_t settingVal)
  * {
- *     printf("%s %s\n", label, selected ? "selected" : "scrolled to");
+ *     printf("%s %s, setting=%d\n", label, selected ? "selected" : "scrolled to", settingVal);
  * }
  * \endcode
  *

--- a/main/menu/menu.h
+++ b/main/menu/menu.h
@@ -195,7 +195,7 @@ void addSettingsItemToMenu(menu_t* menu, const char* label, const settingParam_t
 void removeSettingsItemFromMenu(menu_t* menu, const char* label);
 void addSettingsOptionsItemToMenu(menu_t* menu, const char* const* optionLabels, const int32_t* optionValues,
                                   uint8_t numOptions, const settingParam_t* bounds, int32_t currentOption);
-void removeSettingsOptionsItemToMenu(menu_t menu, const char* const* optionLabels);
+void removeSettingsOptionsItemFromMenu(menu_t* menu, const char* const* optionLabels);
 menu_t* menuButton(menu_t* menu, buttonEvt_t btn) __attribute__((warn_unused_result));
 
 #endif

--- a/main/menu/menu.h
+++ b/main/menu/menu.h
@@ -188,8 +188,9 @@ void addMultiItemToMenu(menu_t* menu, const char* const* labels, uint8_t numLabe
 void removeMultiItemFromMenu(menu_t* menu, const char* const* labels);
 void addSettingsItemToMenu(menu_t* menu, const char* label, const settingParam_t* bounds, int32_t val);
 void removeSettingsItemFromMenu(menu_t* menu, const char* label);
-void addSettingsOptionsItemToMenu(menu_t* menu, const char* const* optionLabels, const int32_t* optionValues, uint8_t numOptions, const settingParam_t* bounds, int32_t currentOption);
-void removeSettingsOptionsItemToMenu(menu_t menu, const char* const *optionLabels);
+void addSettingsOptionsItemToMenu(menu_t* menu, const char* const* optionLabels, const int32_t* optionValues,
+                                  uint8_t numOptions, const settingParam_t* bounds, int32_t currentOption);
+void removeSettingsOptionsItemToMenu(menu_t menu, const char* const* optionLabels);
 menu_t* menuButton(menu_t* menu, buttonEvt_t btn) __attribute__((warn_unused_result));
 
 #endif

--- a/main/menu/menu.h
+++ b/main/menu/menu.h
@@ -159,6 +159,7 @@ typedef struct
     uint8_t currentOpt;         ///< The current selected option for multi-select
     uint8_t minSetting;         ///< The minimum value for settings items
     uint8_t maxSetting;         ///< The maximum value for settings items
+    const int32_t* settingVals; ///< The setting value options for settings-options items
     uint8_t currentSetting;     // The current value for settings items
 } menuItem_t;
 
@@ -187,6 +188,8 @@ void addMultiItemToMenu(menu_t* menu, const char* const* labels, uint8_t numLabe
 void removeMultiItemFromMenu(menu_t* menu, const char* const* labels);
 void addSettingsItemToMenu(menu_t* menu, const char* label, const settingParam_t* bounds, int32_t val);
 void removeSettingsItemFromMenu(menu_t* menu, const char* label);
+void addSettingsOptionsItemToMenu(menu_t* menu, const char* const* optionLabels, const int32_t* optionValues, uint8_t numOptions, const settingParam_t* bounds, int32_t currentOption);
+void removeSettingsOptionsItemToMenu(menu_t menu, const char* const *optionLabels);
 menu_t* menuButton(menu_t* menu, buttonEvt_t btn) __attribute__((warn_unused_result));
 
 #endif

--- a/main/menu/menuLogbookRenderer.c
+++ b/main/menu/menuLogbookRenderer.c
@@ -299,7 +299,7 @@ void drawMenuLogbook(menu_t* menu, menuLogbookRenderer_t* renderer, int64_t elap
             bool isSelected  = (menu->currentItem->val == item);
 
             // Draw the label(s)
-            if (item->minSetting != item->maxSetting)
+            if (item->minSetting != item->maxSetting && !item->options)
             {
                 // Create key and value label, then draw it
                 char label[64] = {0};

--- a/main/menu/menuLogbookRenderer.c
+++ b/main/menu/menuLogbookRenderer.c
@@ -299,11 +299,19 @@ void drawMenuLogbook(menu_t* menu, menuLogbookRenderer_t* renderer, int64_t elap
             bool isSelected  = (menu->currentItem->val == item);
 
             // Draw the label(s)
-            if (item->minSetting != item->maxSetting && !item->options)
+            if (item->minSetting != item->maxSetting)
             {
                 // Create key and value label, then draw it
                 char label[64] = {0};
-                snprintf(label, sizeof(label) - 1, "%s: %d", item->label, item->currentSetting);
+                if (item->options)
+                {
+                    snprintf(label, sizeof(label) - 1, "%s%s", item->label, item->options[item->currentOpt]);
+                }
+                else
+                {
+                    snprintf(label, sizeof(label) - 1, "%s: %d", item->label, item->currentSetting);
+                }
+
                 drawMenuText(renderer, label, x, y, isSelected, item->currentSetting != item->minSetting,
                              item->currentSetting != item->maxSetting, false);
             }

--- a/main/modes/mainMenu/mainMenu.c
+++ b/main/modes/mainMenu/mainMenu.c
@@ -59,32 +59,25 @@ mainMenu_t* mainMenu;
 
 static const char settingsLabel[] = "Settings";
 
-static const char tftSettingLabel[]         = "TFT";
-static const char ledSettingLabel[]         = "LED";
-static const char bgmVolSettingLabel[]      = "BGM";
-static const char sfxVolSettingLabel[]      = "SFX";
-static const char micSettingLabel[]         = "MIC";
+static const char tftSettingLabel[]    = "TFT";
+static const char ledSettingLabel[]    = "LED";
+static const char bgmVolSettingLabel[] = "BGM";
+static const char sfxVolSettingLabel[] = "SFX";
+static const char micSettingLabel[]    = "MIC";
 
-static const int32_t screenSaverSettingsValues[] =
-{
-    0,  // Off
-    10, // 10sec
-    20, // 20sec
-    30, // 30sec
-    60, // 60sec
-    120,    // 2min
-    300,    // 5min
+static const int32_t screenSaverSettingsValues[] = {
+    0,   // Off
+    10,  // 10sec
+    20,  // 20sec
+    30,  // 30sec
+    60,  // 60sec
+    120, // 2min
+    300, // 5min
 };
 
-static const char* screenSaverSettingsOptions[] =
-{
-    "Screen Saver: Off",
-    "Screen Saver: 10s",
-    "Screen Saver: 20s",
-    "Screen Saver: 30s",
-    "Screen Saver: 1m",
-    "Screen Saver: 2m",
-    "Screen Saver: 5m",
+static const char* screenSaverSettingsOptions[] = {
+    "Screen Saver: Off", "Screen Saver: 10s", "Screen Saver: 20s", "Screen Saver: 30s",
+    "Screen Saver: 1m",  "Screen Saver: 2m",  "Screen Saver: 5m",
 };
 
 //==============================================================================
@@ -122,9 +115,9 @@ static void mainMenuEnterMode(void)
     addSettingsItemToMenu(mainMenu->menu, sfxVolSettingLabel, getSfxVolumeSettingBounds(), getSfxVolumeSetting());
     addSettingsItemToMenu(mainMenu->menu, micSettingLabel, getMicGainSettingBounds(), getMicGainSetting());
 
-    addSettingsOptionsItemToMenu(mainMenu->menu,
-                                 screenSaverSettingsOptions, screenSaverSettingsValues, ARRAY_SIZE(screenSaverSettingsValues),
-                                 getScreensaverTimeSettingBounds(), getScreensaverTimeSetting());
+    addSettingsOptionsItemToMenu(mainMenu->menu, screenSaverSettingsOptions, screenSaverSettingsValues,
+                                 ARRAY_SIZE(screenSaverSettingsValues), getScreensaverTimeSettingBounds(),
+                                 getScreensaverTimeSetting());
     // End the submenu for settings
     mainMenu->menu = endSubMenu(mainMenu->menu);
 
@@ -221,7 +214,8 @@ static void mainMenuCb(const char* label, bool selected, uint32_t settingVal)
         {
             setMicGainSetting(settingVal);
         }
-        else if (screenSaverSettingsOptions <= label && label < screenSaverSettingsOptions + ARRAY_SIZE(screenSaverSettingsOptions))
+        else if (screenSaverSettingsOptions <= label
+                 && label < screenSaverSettingsOptions + ARRAY_SIZE(screenSaverSettingsOptions))
         {
             setScreensaverTimeSetting(settingVal);
         }

--- a/main/modes/mainMenu/mainMenu.c
+++ b/main/modes/mainMenu/mainMenu.c
@@ -31,6 +31,7 @@ static void mainMenuEnterMode(void);
 static void mainMenuExitMode(void);
 static void mainMenuMainLoop(int64_t elapsedUs);
 static void mainMenuCb(const char* label, bool selected, uint32_t settingVal);
+static bool isScreenSaverOptionLabel(const char* label);
 
 //==============================================================================
 // Variables
@@ -75,7 +76,7 @@ static const int32_t screenSaverSettingsValues[] = {
     300, // 5min
 };
 
-static const char* screenSaverSettingsOptions[] = {
+static const char* const screenSaverSettingsOptions[] = {
     "Screensaver: Off", "Screensaver: 10s", "Screensaver: 20s", "Screensaver: 30s",
     "Screensaver: 1m",  "Screensaver: 2m",  "Screensaver: 5m",
 };
@@ -83,6 +84,23 @@ static const char* screenSaverSettingsOptions[] = {
 //==============================================================================
 // Functions
 //==============================================================================
+
+/**
+ * @brief Local helper function to check if the label is one of the screensaver values
+ *
+ */
+static bool isScreenSaverOptionLabel(const char* label)
+{
+    for (uint8_t i = 0; i < ARRAY_SIZE(screenSaverSettingsOptions); i++)
+    {
+        if (label == screenSaverSettingsOptions[i])
+        {
+            return true;
+        }
+    }
+
+    return false;
+}
 
 /**
  * @brief Initialize the main menu mode
@@ -214,8 +232,7 @@ static void mainMenuCb(const char* label, bool selected, uint32_t settingVal)
         {
             setMicGainSetting(settingVal);
         }
-        else if (*screenSaverSettingsOptions <= label
-                 && label <= *(screenSaverSettingsOptions + ARRAY_SIZE(screenSaverSettingsOptions) - 1))
+        else if (isScreenSaverOptionLabel(label))
         {
             setScreensaverTimeSetting(settingVal);
         }

--- a/main/modes/mainMenu/mainMenu.c
+++ b/main/modes/mainMenu/mainMenu.c
@@ -31,7 +31,6 @@ static void mainMenuEnterMode(void);
 static void mainMenuExitMode(void);
 static void mainMenuMainLoop(int64_t elapsedUs);
 static void mainMenuCb(const char* label, bool selected, uint32_t settingVal);
-static bool isScreenSaverOptionLabel(const char* label);
 
 //==============================================================================
 // Variables
@@ -60,11 +59,12 @@ mainMenu_t* mainMenu;
 
 static const char settingsLabel[] = "Settings";
 
-static const char tftSettingLabel[]    = "TFT";
-static const char ledSettingLabel[]    = "LED";
-static const char bgmVolSettingLabel[] = "BGM";
-static const char sfxVolSettingLabel[] = "SFX";
-static const char micSettingLabel[]    = "MIC";
+static const char tftSettingLabel[]          = "TFT";
+static const char ledSettingLabel[]          = "LED";
+static const char bgmVolSettingLabel[]       = "BGM";
+static const char sfxVolSettingLabel[]       = "SFX";
+static const char micSettingLabel[]          = "MIC";
+static const char screenSaverSettingsLabel[] = "Screensaver: ";
 
 static const int32_t screenSaverSettingsValues[] = {
     0,   // Off
@@ -77,30 +77,12 @@ static const int32_t screenSaverSettingsValues[] = {
 };
 
 static const char* const screenSaverSettingsOptions[] = {
-    "Screensaver: Off", "Screensaver: 10s", "Screensaver: 20s", "Screensaver: 30s",
-    "Screensaver: 1m",  "Screensaver: 2m",  "Screensaver: 5m",
+    "Off", "10s", "20s", "30s", "1m", "2m", "5m",
 };
 
 //==============================================================================
 // Functions
 //==============================================================================
-
-/**
- * @brief Local helper function to check if the label is one of the screensaver values
- *
- */
-static bool isScreenSaverOptionLabel(const char* label)
-{
-    for (uint8_t i = 0; i < ARRAY_SIZE(screenSaverSettingsOptions); i++)
-    {
-        if (label == screenSaverSettingsOptions[i])
-        {
-            return true;
-        }
-    }
-
-    return false;
-}
 
 /**
  * @brief Initialize the main menu mode
@@ -133,9 +115,9 @@ static void mainMenuEnterMode(void)
     addSettingsItemToMenu(mainMenu->menu, sfxVolSettingLabel, getSfxVolumeSettingBounds(), getSfxVolumeSetting());
     addSettingsItemToMenu(mainMenu->menu, micSettingLabel, getMicGainSettingBounds(), getMicGainSetting());
 
-    addSettingsOptionsItemToMenu(mainMenu->menu, screenSaverSettingsOptions, screenSaverSettingsValues,
-                                 ARRAY_SIZE(screenSaverSettingsValues), getScreensaverTimeSettingBounds(),
-                                 getScreensaverTimeSetting());
+    addSettingsOptionsItemToMenu(mainMenu->menu, screenSaverSettingsLabel, screenSaverSettingsOptions,
+                                 screenSaverSettingsValues, ARRAY_SIZE(screenSaverSettingsValues),
+                                 getScreensaverTimeSettingBounds(), getScreensaverTimeSetting());
     // End the submenu for settings
     mainMenu->menu = endSubMenu(mainMenu->menu);
 
@@ -232,7 +214,7 @@ static void mainMenuCb(const char* label, bool selected, uint32_t settingVal)
         {
             setMicGainSetting(settingVal);
         }
-        else if (isScreenSaverOptionLabel(label))
+        else if (screenSaverSettingsLabel == label)
         {
             setScreensaverTimeSetting(settingVal);
         }

--- a/main/modes/mainMenu/mainMenu.c
+++ b/main/modes/mainMenu/mainMenu.c
@@ -64,7 +64,28 @@ static const char ledSettingLabel[]         = "LED";
 static const char bgmVolSettingLabel[]      = "BGM";
 static const char sfxVolSettingLabel[]      = "SFX";
 static const char micSettingLabel[]         = "MIC";
-static const char screenSaverSettingLabel[] = "Screen Saver";
+
+static const int32_t screenSaverSettingsValues[] =
+{
+    0,  // Off
+    10, // 10sec
+    20, // 20sec
+    30, // 30sec
+    60, // 60sec
+    120,    // 2min
+    300,    // 5min
+};
+
+static const char* screenSaverSettingsOptions[] =
+{
+    "Screen Saver: Off",
+    "Screen Saver: 10s",
+    "Screen Saver: 20s",
+    "Screen Saver: 30s",
+    "Screen Saver: 1m",
+    "Screen Saver: 2m",
+    "Screen Saver: 5m",
+};
 
 //==============================================================================
 // Functions
@@ -100,8 +121,10 @@ static void mainMenuEnterMode(void)
     addSettingsItemToMenu(mainMenu->menu, bgmVolSettingLabel, getBgmVolumeSettingBounds(), getBgmVolumeSetting());
     addSettingsItemToMenu(mainMenu->menu, sfxVolSettingLabel, getSfxVolumeSettingBounds(), getSfxVolumeSetting());
     addSettingsItemToMenu(mainMenu->menu, micSettingLabel, getMicGainSettingBounds(), getMicGainSetting());
-    addSettingsItemToMenu(mainMenu->menu, screenSaverSettingLabel, getScreensaverTimeSettingBounds(),
-                          getScreensaverTimeSetting());
+
+    addSettingsOptionsItemToMenu(mainMenu->menu,
+                                 screenSaverSettingsOptions, screenSaverSettingsValues, ARRAY_SIZE(screenSaverSettingsValues),
+                                 getScreensaverTimeSettingBounds(), getScreensaverTimeSetting());
     // End the submenu for settings
     mainMenu->menu = endSubMenu(mainMenu->menu);
 
@@ -198,7 +221,7 @@ static void mainMenuCb(const char* label, bool selected, uint32_t settingVal)
         {
             setMicGainSetting(settingVal);
         }
-        else if (screenSaverSettingLabel == label)
+        else if (screenSaverSettingsOptions <= label && label < screenSaverSettingsOptions + ARRAY_SIZE(screenSaverSettingsOptions))
         {
             setScreensaverTimeSetting(settingVal);
         }

--- a/main/modes/mainMenu/mainMenu.c
+++ b/main/modes/mainMenu/mainMenu.c
@@ -76,8 +76,8 @@ static const int32_t screenSaverSettingsValues[] = {
 };
 
 static const char* screenSaverSettingsOptions[] = {
-    "Screen Saver: Off", "Screen Saver: 10s", "Screen Saver: 20s", "Screen Saver: 30s",
-    "Screen Saver: 1m",  "Screen Saver: 2m",  "Screen Saver: 5m",
+    "Screensaver: Off", "Screensaver: 10s", "Screensaver: 20s", "Screensaver: 30s",
+    "Screensaver: 1m",  "Screensaver: 2m",  "Screensaver: 5m",
 };
 
 //==============================================================================
@@ -214,8 +214,8 @@ static void mainMenuCb(const char* label, bool selected, uint32_t settingVal)
         {
             setMicGainSetting(settingVal);
         }
-        else if (screenSaverSettingsOptions <= label
-                 && label < screenSaverSettingsOptions + ARRAY_SIZE(screenSaverSettingsOptions))
+        else if (*screenSaverSettingsOptions <= label
+                 && label <= *(screenSaverSettingsOptions + ARRAY_SIZE(screenSaverSettingsOptions) - 1))
         {
             setScreensaverTimeSetting(settingVal);
         }

--- a/main/utils/settingsManager.c
+++ b/main/utils/settingsManager.c
@@ -57,7 +57,7 @@ DECL_SETTING(tft_br, 0, 7, 5);
 DECL_SETTING(led_br, 0, 8, 5);
 DECL_SETTING(mic, 0, 7, 7);
 DECL_SETTING(cc_mode, ALL_SAME_LEDS, LINEAR_LEDS, ALL_SAME_LEDS);
-DECL_SETTING(scrn_sv, 0, 6, 2);
+DECL_SETTING(scrn_sv, 0, 300, 20);
 
 //==============================================================================
 // Static Function Prototypes


### PR DESCRIPTION
### Description

<!--- What was added and/or fixed in this pull request? -->
This adds the multi-option settings item menu item as described in #33.

### Test Instructions

<!--- How was this tested? -->

Testing:
1. Open the main menu
2. Go to settings
3. Scroll down to **Screensaver** and change the settings by scrolling left or right.
4. Make sure scrolling past the ends doesn't break anything and wraps correctly.
5. Go to the main menu and open some other mode (pong)
6. Go back to the settings menu and check that the screensaver setting is correct.

### Ticket Links

<!--- Link any tickets that are completed in this pull request. -->

Closes #33 

### Readiness Checklist
- [x] I have run `make format` to format the changes
- [x] I have compiled the firmware and the changes have no warnings
- [x] I have compiled the emulator and the changes have no warnings
- [x] I have run `make cppcheck` and checked that `cppcheck_result.txt` has no warnings for the changes
- [x] I have added doxygen comments to any code used by more than one Swadge mode. This includes `/*! \file` comments with Design Philosophy, Usage, and Example sections for new headers.
- [x] I have run `make docs` and checked that `doxy_warnings.txt` has no warnings for the new code




