### PR TITLE
Fix PR head message in build GHA

### DIFF
--- a/.github/workflows/build-firmware-and-emulator.yml
+++ b/.github/workflows/build-firmware-and-emulator.yml
@@ -31,7 +31,7 @@ jobs:
         
     - name: Extract head commit info
       run: |
-        echo "HEAD_COMMIT_INFO='$(git show -s --format=medium ${{ github.event.head_commit.sha }})'">> $GITHUB_ENV
+        echo "HEAD_COMMIT_INFO='$(git show -s --format=medium ${{ github.event.pull_request.head.sha }})'">> $GITHUB_ENV
     
     - name: Post to a Slack channel
       id: slack


### PR DESCRIPTION
### Description

<!--- What was added and/or fixed in this pull request? -->

Fixes the build GHA so it will post the head commit message from in progress PRs.

<!--- How was this tested? -->

Tested on my own fork by opening (this) PR and observing the results.