### PR TITLE
Fix main menu buzzing forever

### DIFF
--- a/main/menu/menu.c
+++ b/main/menu/menu.c
@@ -29,9 +29,9 @@ static void deinitSubMenu(menu_t* menu);
  * scrollable rows. The rows are separated into pages, and when a page
  * boundary is crossed the whole page scrolls.
  *
- * Rows may be single items, where the callback is called whenever it is
- * selected or multi items, which is a collection of horizontally scrollable
- * items and the callback is called whenever it scrolls or is selected.
+ * Rows may be single items, or multi items, which are collections of horizontally
+ * scrollable items. The callback is called whenever a row is moved to or selected,
+ * and when a multi item is scrolled to or selected.
  *
  * Rows may also be submenus. When a submenu is selected, the callback is not
  * called, and instead a the submenu is rendered. Each submenu automatically

--- a/main/menu/menu.c
+++ b/main/menu/menu.c
@@ -500,9 +500,12 @@ menu_t* menuButton(menu_t* menu, buttonEvt_t btn)
 
                 // Call the callback for the move
                 item = menu->currentItem->val;
+
                 menu->cbFunc(
-                    item->options ? item->options[item->currentOpt] : item->label,
+                    // If the item is a non-setting item with options, pass the option label. Otherwise, the main label
+                    (item->options && !item->settingVals) ? item->options[item->currentOpt] : item->label,
                     false,
+                    // If the item is a setting with options, pass the current option value. Otherwise, the regular setting
                     item->settingVals ? item->settingVals[item->currentOpt] : item->currentSetting
                 );
 
@@ -521,9 +524,12 @@ menu_t* menuButton(menu_t* menu, buttonEvt_t btn)
                 }
 
                 item = menu->currentItem->val;
+
                 menu->cbFunc(
-                    item->options ? item->options[item->currentOpt] : item->label,
+                    // If the item is a non-setting item with options, pass the option label. Otherwise, the main label
+                    (item->options && !item->settingVals) ? item->options[item->currentOpt] : item->label,
                     false,
+                    // If the item is a setting with options, pass the current option value. Otherwise, the regular setting
                     item->settingVals ? item->settingVals[item->currentOpt] : item->currentSetting
                 );
 

--- a/main/menu/menu.c
+++ b/main/menu/menu.c
@@ -497,6 +497,15 @@ menu_t* menuButton(menu_t* menu, buttonEvt_t btn)
                 {
                     menu->currentItem = menu->currentItem->prev;
                 }
+
+                // Call the callback for the move
+                item = menu->currentItem->val;
+                menu->cbFunc(
+                    item->options ? item->options[item->currentOpt] : item->label,
+                    false,
+                    item->settingVals ? item->settingVals[item->currentOpt] : item->currentSetting
+                );
+
                 break;
             }
             case PB_DOWN:
@@ -510,6 +519,14 @@ menu_t* menuButton(menu_t* menu, buttonEvt_t btn)
                 {
                     menu->currentItem = menu->currentItem->next;
                 }
+
+                item = menu->currentItem->val;
+                menu->cbFunc(
+                    item->options ? item->options[item->currentOpt] : item->label,
+                    false,
+                    item->settingVals ? item->settingVals[item->currentOpt] : item->currentSetting
+                );
+
                 break;
             }
             case PB_LEFT:

--- a/main/menu/menu.c
+++ b/main/menu/menu.c
@@ -503,11 +503,10 @@ menu_t* menuButton(menu_t* menu, buttonEvt_t btn)
 
                 menu->cbFunc(
                     // If the item is a non-setting item with options, pass the option label. Otherwise, the main label
-                    (item->options && !item->settingVals) ? item->options[item->currentOpt] : item->label,
-                    false,
-                    // If the item is a setting with options, pass the current option value. Otherwise, the regular setting
-                    item->settingVals ? item->settingVals[item->currentOpt] : item->currentSetting
-                );
+                    (item->options && !item->settingVals) ? item->options[item->currentOpt] : item->label, false,
+                    // If the item is a setting with options, pass the current option value. Otherwise, the regular
+                    // setting
+                    item->settingVals ? item->settingVals[item->currentOpt] : item->currentSetting);
 
                 break;
             }
@@ -527,11 +526,10 @@ menu_t* menuButton(menu_t* menu, buttonEvt_t btn)
 
                 menu->cbFunc(
                     // If the item is a non-setting item with options, pass the option label. Otherwise, the main label
-                    (item->options && !item->settingVals) ? item->options[item->currentOpt] : item->label,
-                    false,
-                    // If the item is a setting with options, pass the current option value. Otherwise, the regular setting
-                    item->settingVals ? item->settingVals[item->currentOpt] : item->currentSetting
-                );
+                    (item->options && !item->settingVals) ? item->options[item->currentOpt] : item->label, false,
+                    // If the item is a setting with options, pass the current option value. Otherwise, the regular
+                    // setting
+                    item->settingVals ? item->settingVals[item->currentOpt] : item->currentSetting);
 
                 break;
             }

--- a/main/modes/mainMenu/mainMenu.c
+++ b/main/modes/mainMenu/mainMenu.c
@@ -173,6 +173,10 @@ static void mainMenuMainLoop(int64_t elapsedUs)
  */
 static void mainMenuCb(const char* label, bool selected, uint32_t settingVal)
 {
+    // Stop the buzzer first no matter what, so that it turns off
+    // if we scroll away from the BGM or SFX settings.
+    bzrStop();
+
     if (selected)
     {
         // These items enter other modes, so they must be selected


### PR DESCRIPTION
### Description

<!--- What was added and/or fixed in this pull request? -->

In the main menu mode, when the BGM and SFX settings are changed, sound begins playing. However, after scrolling away from the settings, sound continues playing forever, until the mode is changed or something else plays sound.

This PR addresses that issue by stopping the buzzer whenever the menu item changes. In order to do that, `::menuCb` in `menu.c` was updated to now call the callback when scrolling between menu items, so that the callback can actually stop the buzzer.

### Test Instructions

<!--- How was this tested? -->

On the main menu, go to Settings, then scroll down to BGM or SFX. Change the setting value and note the sound playing, then scroll to a different menu item (not BGM or SFX). The sound should stop playing.

Also, scroll around the other settings and general menu things and see that nothing is behaving strangely due to the added callback (they should be fine if they're checking the `selected` value properly).

### Ticket Links

<!--- Link any tickets that are completed in this pull request. -->

### Readiness Checklist
- [x] I have run `make format` to format the changes
- [x] I have compiled the firmware and the changes have no warnings
- [x] I have compiled the emulator and the changes have no warnings
- [x] I have run `make cppcheck` and checked that `cppcheck_result.txt` has no warnings for the changes
- [x] I have added doxygen comments to any code used by more than one Swadge mode. This includes `/*! \file` comments with Design Philosophy, Usage, and Example sections for new headers.
- [x] I have run `make docs` and checked that `doxy_warnings.txt` has no warnings for the new code
