### PR TITLE
Fix confusing parameter name in `menuButton`

### DIFF
--- a/main/menu/menu.c
+++ b/main/menu/menu.c
@@ -474,17 +474,17 @@ void removeSettingsOptionsItemFromMenu(menu_t* menu, const char* const* optionLa
  * If a button is passed here, it should not be handled anywhere else
  *
  * @param menu The menu to process button events for
- * @param btn The button event that occurred
+ * @param evt The button event that occurred
  * @return A pointer to the menu to use for future function calls. It may be a sub or parent menu.
  */
-menu_t* menuButton(menu_t* menu, buttonEvt_t btn)
+menu_t* menuButton(menu_t* menu, buttonEvt_t evt)
 {
-    if (btn.down)
+    if (evt.down)
     {
         // Get a pointer to the item for convenience
         menuItem_t* item = menu->currentItem->val;
 
-        switch (btn.button)
+        switch (evt.button)
         {
             case PB_UP:
             {

--- a/main/menu/menu.h
+++ b/main/menu/menu.h
@@ -198,6 +198,6 @@ void addSettingsOptionsItemToMenu(menu_t* menu, const char* settingLabel, const 
                                   const int32_t* optionValues, uint8_t numOptions, const settingParam_t* bounds,
                                   int32_t currentOption);
 void removeSettingsOptionsItemFromMenu(menu_t* menu, const char* const* optionLabels);
-menu_t* menuButton(menu_t* menu, buttonEvt_t btn) __attribute__((warn_unused_result));
+menu_t* menuButton(menu_t* menu, buttonEvt_t evt) __attribute__((warn_unused_result));
 
 #endif


### PR DESCRIPTION
### Description

<!--- What was added and/or fixed in this pull request? -->
Confusion was mitigated

### Test Instructions

<!--- How was this tested? -->
Compiled and tested on emulator and hardware

### Ticket Links

<!--- Link any tickets that are completed in this pull request. -->

### Readiness Checklist
- [ ] I have run `make format` to format the changes
- [x] I have compiled the firmware and the changes have no warnings
- [x] I have compiled the emulator and the changes have no warnings
- [x] I have run `make cppcheck` and checked that `cppcheck_result.txt` has no warnings for the changes
- [x] I have added doxygen comments to any code used by more than one Swadge mode. This includes `/*! \file` comments with Design Philosophy, Usage, and Example sections for new headers.
- [x] I have run `make docs` and checked that `doxy_warnings.txt` has no warnings for the new code
