### PR TITLE
Porting docs

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -917,7 +917,7 @@ WARN_LOGFILE           = doxy_warnings.txt
 # spaces. See also FILE_PATTERNS and EXTENSION_MAPPING
 # Note: If this tag is empty the current directory is searched.
 
-INPUT                  = ./main ./components ./docs/SETUP.md ./docs/CONTRIBUTING.md ./docs/CODE_OF_CONDUCT.md
+INPUT                  = ./main ./components ./docs/SETUP.md ./docs/CONTRIBUTING.md ./docs/CODE_OF_CONDUCT.md ./docs/PORTING.md
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses

--- a/docs/PORTING.md
+++ b/docs/PORTING.md
@@ -1,6 +1,8 @@
+# Porting 2023 Swadge Modes {#porting}
+
 This is a non-exhaustive list of changes I've found to be needed when porting Tunernome. They should cut down on time required to port modes from 2023. If porting from pre-2023, check out [this similar list I made last year](https://github.com/AEFeinstein/Super-2023-Swadge-FW/issues/31#issuecomment-1221395802).
 
-# Changes that involve re-design
+## Changes that involve re-design
 
 - `mm.font` has been removed. The closest font is `logbook.font` which is 3 pixels smaller in height. Arrows and symbol `wsg`s need to be updated for the smaller font too.
 - Accel, touch, and button callbacks no longer exist. Instead, checks must be done in the main loop function. This can be used to more easily adapt button callbacks to the new standard:
@@ -18,7 +20,7 @@ while (checkButtonQueueWrapper(&evt))
 // The rest of your mainLoop function
 ```
 
-# Things that need to be changed in mode header files
+## Things that need to be changed in mode header files
 
 - Add `#include "swadge2024.h"`
 - Naming conventions changed from `mode_tunernome.h` to `tunernome.h`. Don't forget to change your header guard names too:
@@ -28,17 +30,17 @@ _MODE_TUNERNOME_H_
 _TUNERNOME_H_
 ```
 
-# Things that need to be added to `enterMode` and `exitMode` functions
+## Things that need to be added to `enterMode` and `exitMode` functions
 
 - `tunernome->menuRenderer = initMenuLogbookRenderer(&tunernome->logbookFont);`
 
 - `deinitMenuLogbookRenderer(tunernome->renderer);`
 
-# Things that need to be intelligently deleted
+## Things that need to be intelligently deleted
 
 - `tunernome->disp`
 
-# Things that need to be intelligently changed or replaced
+## Things that need to be intelligently changed or replaced
 
 ```
 modeTunernome
@@ -108,7 +110,7 @@ drawMeleeMenu(tunernome->menu);
 drawMenuLogbook(tunernome->menu, tunernome->renderer, elapsedUs);
 ```
 
-# Things that can be find/replaced
+## Things that can be find/replaced
 
 ```
 swadgeMode

--- a/docs/PORTING.md
+++ b/docs/PORTING.md
@@ -7,7 +7,7 @@ This is a non-exhaustive list of changes I've found to be needed when porting Tu
 - `mm.font` has been removed. The closest font is `logbook.font` which is 3 pixels smaller in height. Arrows and symbol `wsg`s need to be updated for the smaller font too.
 - Accel, touch, and button callbacks no longer exist. Instead, checks must be done in the main loop function. This can be used to more easily adapt button callbacks to the new standard:
 
-```
+```c
 buttonEvt_t evt = {0};
 while (checkButtonQueueWrapper(&evt))
 {
@@ -25,15 +25,14 @@ while (checkButtonQueueWrapper(&evt))
 - Add `#include "swadge2024.h"`
 - Naming conventions changed from `mode_tunernome.h` to `tunernome.h`. Don't forget to change your header guard names too:
 
-```
+```c
 _MODE_TUNERNOME_H_
 _TUNERNOME_H_
 ```
 
-## Things that need to be added to `enterMode` and `exitMode` functions
+## Things that need to be added to enterMode() and exitMode() functions
 
 - `tunernome->menuRenderer = initMenuLogbookRenderer(&tunernome->logbookFont);`
-
 - `deinitMenuLogbookRenderer(tunernome->renderer);`
 
 ## Things that need to be intelligently deleted
@@ -42,149 +41,57 @@ _TUNERNOME_H_
 
 ## Things that need to be intelligently changed or replaced
 
-```
-modeTunernome
-tunernomeMode
-
-drawText(tunernome->disp, 
-drawText(
-
-fillDisplayArea(tunernome->disp, 
-fillDisplayArea(
-
-drawWsg(tunernome->disp, 
-drawWsg(
-
-plotLine(tunernome->disp, 
-drawLine(
-
-plotCircleQuadrants(tunernome->disp, 
-drawCircleQuadrants(
-
-plotCircleFilled(tunernome->disp, 
-drawCircleFilled(
-
-plotCircle(tunernome->disp, 
-drawCircle(
-
-plotRect(tunernome->disp, 
-plotRect(
-
-tunernome->disp->clearPx();
-clearPxTft();
-
-tunernome->disp->w
-TFT_WIDTH
-
-tunernome->disp->h
-TFT_HEIGHT
-
-ibm_vga8.h
-ibm_vga8.height
-
-mm.h
-mm.height
-
-radiostars.h
-radiostars.height
-
-loadFont(const char* name, font_t* font)
-loadFont(const char* name, font_t* font, bool spiRam)
-
-bool loadWsg(char* name, wsg_t* wsg)
-bool loadWsg(char* name, wsg_t* wsg, bool spiRam)
-
-menu->selectedRow
-menu->currentItem
-
-menu->rows
-menu->items
-
-initMeleeMenu(modeTunernome.modeName, &(tunernome->mm), tunernomeMainMenuCb);
-initMenu(tunernomeMode.modeName, tunernomeMainMenuCb);
-
-tunernomeMenuCb(const char* opt)
-mainMenuCb(const char* label, bool selected, uint32_t settingVal)
-
-drawMeleeMenu(tunernome->menu);
-drawMenuLogbook(tunernome->menu, tunernome->renderer, elapsedUs);
-```
+| Old                                                                             | New                                                                 |
+|---------------------------------------------------------------------------------|---------------------------------------------------------------------|
+| `modeTunernome`                                                                 | `tunernomeMode`                                                     |
+| `drawText(tunernome->disp, `                                                    | `drawText(`                                                         |
+| `fillDisplayArea(tunernome->disp, `                                             | `fillDisplayArea(`                                                  |
+| `drawWsg(tunernome->disp, `                                                     | `drawWsg(`                                                          |
+| `plotLine(tunernome->disp, `                                                    | `drawLine(`                                                         |
+| `plotCircleQuadrants(tunernome->disp, `                                         | `drawCircleQuadrants(`                                              |
+| `plotCircleFilled(tunernome->disp, `                                            | `drawCircleFilled(`                                                 |
+| `plotCircle(tunernome->disp, `                                                  | `drawCircle(`                                                       |
+| `plotRect(tunernome->disp, `                                                    | `plotRect(`                                                         |
+| `tunernome->disp->clearPx();`                                                   | `clearPxTft();`                                                     |
+| `tunernome->disp->w`                                                            | `TFT_WIDTH`                                                         |
+| `tunernome->disp->h`                                                            | `TFT_HEIGHT`                                                        |
+| `ibm_vga8.h`                                                                    | `ibm_vga8.height`                                                   |
+| `mm.h`                                                                          | `mm.height`                                                         |
+| `radiostars.h`                                                                  | `radiostars.height`                                                 |
+| `loadFont(const char* name, font_t* font)`                                      | `loadFont(const char* name, font_t* font, bool spiRam)`             |
+| `bool loadWsg(char* name, wsg_t* wsg)`                                          | `bool loadWsg(char* name, wsg_t* wsg, bool spiRam)`                 |
+| `menu->selectedRow`                                                             | `menu->currentItem`                                                 |
+| `menu->rows`                                                                    | `menu->items`                                                       |
+| `initMeleeMenu(modeTunernome.modeName, &(tunernome->mm), tunernomeMainMenuCb);` | `initMenu(tunernomeMode.modeName, tunernomeMainMenuCb);`            |
+| `tunernomeMenuCb(const char* opt)`                                              | `mainMenuCb(const char* label, bool selected, uint32_t settingVal)` |
+| `drawMeleeMenu(tunernome->menu);`                                               | `drawMenuLogbook(tunernome->menu, tunernome->renderer, elapsedUs);` |
 
 ## Things that can be find/replaced
 
-```
-swadgeMode
-swadgeMode_t
-
-NUM_LEDS
-CONFIG_NUM_LEDS
-
-#include "embeddednf.h"
-#include "embeddedNf.h"
-
-#include "embeddedout.h"
-#include "embeddedOut.h"
-
-embeddednf_data
-embeddedNf_data
-
-embeddedout_data
-embeddedOut_data
-
-FIXBPERO
-FIX_B_PER_O
-
-UP
-PB_UP
-
-DOWN
-PB_DOWN
-
-LEFT
-PB_LEFT
-
-RIGHT
-PB_RIGHT
-
-BTN_A
-PB_A
-
-BTN_B
-PB_B
-
-START
-PB_START
-
-SELECT
-PB_SELECT
-
-buzzer_play_sfx(
-bzrPlaySfx(
-
-buzzer_play_bgm(
-bzrPlayBgm(
-
-buzzer_stop(
-bzrStop(
-
-incMicGain()
-incMicGainSetting()
-
-decMicGain()
-decMicGainSetting()
-
-getMicGain()
-getMicGainSetting()
-
-setAndSaveLedBrightness(
-setLedBrightnessSetting(
-
-meleeMenu_t
-menu_t
-
-deinitMeleeMenu(
-deinitMenu(
-
-modeMainMenu
-mainMenuMode
-```
+| Old                        | New                        |
+|----------------------------|----------------------------|
+| `swadgeMode`               | `swadgeMode_t`             |
+| `NUM_LEDS`                 | `CONFIG_NUM_LEDS`          |
+| `#include "embeddednf.h"`  | `#include "embeddedNf.h"`  |
+| `#include "embeddedout.h"` | `#include "embeddedOut.h"` |
+| `embeddednf_data`          | `embeddedNf_data`          |
+| `embeddedout_data`         | `embeddedOut_data`         |
+| `FIXBPERO`                 | `FIX_B_PER_O`              |
+| `UP`                       | `PB_UP`                    |
+| `DOWN`                     | `PB_DOWN`                  |
+| `LEFT`                     | `PB_LEFT`                  |
+| `RIGHT`                    | `PB_RIGHT`                 |
+| `BTN_A`                    | `PB_A`                     |
+| `BTN_B`                    | `PB_B`                     |
+| `START`                    | `PB_START`                 |
+| `SELECT`                   | `PB_SELECT`                |
+| `buzzer_play_sfx(`         | `bzrPlaySfx(`              |
+| `buzzer_play_bgm(`         | `bzrPlayBgm(`              |
+| `buzzer_stop(`             | `bzrStop(`                 |
+| `incMicGain()`             | `incMicGainSetting()`      |
+| `decMicGain()`             | `decMicGainSetting()`      |
+| `getMicGain()`             | `getMicGainSetting()`      |
+| `setAndSaveLedBrightness(` | `setLedBrightnessSetting(` |
+| `meleeMenu_t`              | `menu_t`                   |
+| `deinitMeleeMenu(`         | `deinitMenu(`              |
+| `modeMainMenu`             | `mainMenuMode`             |

--- a/docs/PORTING.md
+++ b/docs/PORTING.md
@@ -1,0 +1,188 @@
+This is a non-exhaustive list of changes I've found to be needed when porting Tunernome. They should cut down on time required to port modes from 2023. If porting from pre-2023, check out [this similar list I made last year](https://github.com/AEFeinstein/Super-2023-Swadge-FW/issues/31#issuecomment-1221395802).
+
+# Changes that involve re-design
+
+- `mm.font` has been removed. The closest font is `logbook.font` which is 3 pixels smaller in height. Arrows and symbol `wsg`s need to be updated for the smaller font too.
+- Accel, touch, and button callbacks no longer exist. Instead, checks must be done in the main loop function. This can be used to more easily adapt button callbacks to the new standard:
+
+```
+buttonEvt_t evt = {0};
+while (checkButtonQueueWrapper(&evt))
+{
+    // If processing menu buttons:
+    tunernome->menu = menuButton(tunernome->menu, evt);
+    // OR, if processing mode buttons:
+    tunernomeButtonCb(&evt);
+}
+...
+// The rest of your mainLoop function
+```
+
+# Things that need to be changed in mode header files
+
+- Add `#include "swadge2024.h"`
+- Naming conventions changed from `mode_tunernome.h` to `tunernome.h`. Don't forget to change your header guard names too:
+
+```
+_MODE_TUNERNOME_H_
+_TUNERNOME_H_
+```
+
+# Things that need to be added to `enterMode` and `exitMode` functions
+
+- `tunernome->menuRenderer = initMenuLogbookRenderer(&tunernome->logbookFont);`
+
+- `deinitMenuLogbookRenderer(tunernome->renderer);`
+
+# Things that need to be intelligently deleted
+
+- `tunernome->disp`
+
+# Things that need to be intelligently changed or replaced
+
+```
+modeTunernome
+tunernomeMode
+
+drawText(tunernome->disp, 
+drawText(
+
+fillDisplayArea(tunernome->disp, 
+fillDisplayArea(
+
+drawWsg(tunernome->disp, 
+drawWsg(
+
+plotLine(tunernome->disp, 
+drawLine(
+
+plotCircleQuadrants(tunernome->disp, 
+drawCircleQuadrants(
+
+plotCircleFilled(tunernome->disp, 
+drawCircleFilled(
+
+plotCircle(tunernome->disp, 
+drawCircle(
+
+plotRect(tunernome->disp, 
+plotRect(
+
+tunernome->disp->clearPx();
+clearPxTft();
+
+tunernome->disp->w
+TFT_WIDTH
+
+tunernome->disp->h
+TFT_HEIGHT
+
+ibm_vga8.h
+ibm_vga8.height
+
+mm.h
+mm.height
+
+radiostars.h
+radiostars.height
+
+loadFont(const char* name, font_t* font)
+loadFont(const char* name, font_t* font, bool spiRam)
+
+bool loadWsg(char* name, wsg_t* wsg)
+bool loadWsg(char* name, wsg_t* wsg, bool spiRam)
+
+menu->selectedRow
+menu->currentItem
+
+menu->rows
+menu->items
+
+initMeleeMenu(modeTunernome.modeName, &(tunernome->mm), tunernomeMainMenuCb);
+initMenu(tunernomeMode.modeName, tunernomeMainMenuCb);
+
+tunernomeMenuCb(const char* opt)
+mainMenuCb(const char* label, bool selected, uint32_t settingVal)
+
+drawMeleeMenu(tunernome->menu);
+drawMenuLogbook(tunernome->menu, tunernome->renderer, elapsedUs);
+```
+
+# Things that can be find/replaced
+
+```
+swadgeMode
+swadgeMode_t
+
+NUM_LEDS
+CONFIG_NUM_LEDS
+
+#include "embeddednf.h"
+#include "embeddedNf.h"
+
+#include "embeddedout.h"
+#include "embeddedOut.h"
+
+embeddednf_data
+embeddedNf_data
+
+embeddedout_data
+embeddedOut_data
+
+FIXBPERO
+FIX_B_PER_O
+
+UP
+PB_UP
+
+DOWN
+PB_DOWN
+
+LEFT
+PB_LEFT
+
+RIGHT
+PB_RIGHT
+
+BTN_A
+PB_A
+
+BTN_B
+PB_B
+
+START
+PB_START
+
+SELECT
+PB_SELECT
+
+buzzer_play_sfx(
+bzrPlaySfx(
+
+buzzer_play_bgm(
+bzrPlayBgm(
+
+buzzer_stop(
+bzrStop(
+
+incMicGain()
+incMicGainSetting()
+
+decMicGain()
+decMicGainSetting()
+
+getMicGain()
+getMicGainSetting()
+
+setAndSaveLedBrightness(
+setLedBrightnessSetting(
+
+meleeMenu_t
+menu_t
+
+deinitMeleeMenu(
+deinitMenu(
+
+modeMainMenu
+mainMenuMode
+```

--- a/main/swadge2024.c
+++ b/main/swadge2024.c
@@ -31,6 +31,7 @@
  * the Swadge firmware.
  * -# When you're ready to make a contribution, read the \ref contribution_guide first to see how to do it in the most
  * productive way.
+ * -# If you want to bring a mode forward from last year's Swadge, take a look at \ref porting.
  * -# Finally, if you want to do lower level or \c component programming, read the \ref espressif_doc to understand the
  * full capability of the ESP32-S2 chip.
  *


### PR DESCRIPTION
### Description

<!--- What was added and/or fixed in this pull request? -->
Created documentation on porting 2023 Swadge modes.

### Test Instructions

<!--- How was this tested? -->

### Ticket Links

<!--- Link any tickets that are completed in this pull request. -->
Replicates documentation from #41, and closes the issue.

### Readiness Checklist

- [x] I have run `make format` to format the changes
- [x] I have compiled the firmware and the changes have no warnings
- [x] I have compiled the emulator and the changes have no warnings
- [x] I have run `make cppcheck` and checked that `cppcheck_result.txt` has no warnings for the changes
- [x] I have added doxygen comments to any code used by more than one Swadge mode. This includes `/*! \file` comments with Design Philosophy, Usage, and Example sections for new headers.
- [ ] I have run `make docs` and checked that `doxy_warnings.txt` has no warnings for the new code
> This complains that `\ref setup`, `\ref contribution guide` and `\ref porting` can't be resolved. All these links are missing from my `index.html`. I'm not sure how I broke this, or how to fix it.
