### PR TITLE
All the arg parsing, none of the dependencies

### DIFF
--- a/.github/workflows/build-firmware-and-emulator.yml
+++ b/.github/workflows/build-firmware-and-emulator.yml
@@ -29,7 +29,7 @@ jobs:
 
     - name: Install msys64 packages
       run: |
-        C:\msys64\usr\bin\bash -lc 'pacman --noconfirm -S base-devel gcc gdb zip libargp-devel'
+        C:\msys64\usr\bin\bash -lc 'pacman --noconfirm -S base-devel mingw-w64-x86_64-gcc mingw-w64-x86_64-gdb mingw-w64-x86_64-clang zip'
 
     - name: Compile the Emulator
       run: |
@@ -50,8 +50,7 @@ jobs:
       with:
         name: ${{ env.EMULATOR_ARTIFACT }}
         path: |
-          C:\msys64\usr\bin\msys-argp-0.dll
-          C:\msys64\usr\bin\msys-2.0.dll
+          C:\msys64\mingw64\bin\libwinpthread-1.dll
 
     - name: Set up the IDF
       run: |

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -34,22 +34,20 @@ The continuous integration for this project runs on a Windows instance. This mea
     ```
 3. [Install `doxygen`](https://www.doxygen.nl/download.html). This is for generating documentation.
 4. [Install `cppcheck`](https://cppcheck.sourceforge.io/). This is for static code analysis.
-5. [Install the latest stable `LLVM`](https://github.com/llvm/llvm-project/releases). This is for `clang-format`, which formats code.
-5. [Install `msys2`](https://www.msys2.org/). This is the toolchain which will build the emulator.
-6. Start an `msys2` shell and run the following command to install all required packages:
+5. [Install `msys2`](https://www.msys2.org/). This is the environment in which the emulator will be built.
+6. Start an `msys2` shell and run the following command to install all required packages for building the emulator:
     ```bash
-    pacman --noconfirm -S base-devel gcc gdb zip libargp-devel
+    pacman --noconfirm -S base-devel mingw-w64-x86_64-gcc mingw-w64-x86_64-gdb mingw-w64-x86_64-clang zip
     ```
 7. Add the following paths to the Windows path variable. [Here are some instructions on how to do that](https://www.architectryan.com/2018/03/17/add-to-the-path-on-windows-10/).
     * `C:\msys64\mingw64\bin`
     * `C:\msys64\usr\bin`
     * `C:\Program Files\doxygen\bin` 
     * `C:\Program Files\Cppcheck`
-    * `C:\Program Files\LLVM\bin`
     
-    You must add the `msys2` paths **after** the `python` paths and **before** `C:\Windows\System32`. This is because the build uses Windows `python`, not msys2's, and it uses msys2 `find.exe`, not System32's. `LLVM` must be last. When it's all set up, it should look something like this:
+    You must add the `msys2` paths **after** the `python` paths and **before** `C:\Windows\System32`. This is because the build uses Windows `python`, not msys2's, and it uses msys2 `find.exe`, not System32's. When it's all set up, it should look something like this:
     
-    ![image](https://github.com/AEFeinstein/Swadge-IDF-5.0/assets/231180/84ccb960-01b7-49f1-b4a5-daa094dba7e7)
+    ![image](https://user-images.githubusercontent.com/231180/224911026-0c6b1063-e4f2-4671-a804-bce004085a3a.png)
 
 8. Clone the ESP-IDF v5.1 and install the tools. Note that it will clone into `$HOME/esp/esp-idf`.
     ```powershell

--- a/emulator/src/extensions/emu_args.c
+++ b/emulator/src/extensions/emu_args.c
@@ -155,13 +155,15 @@ static bool handleArgument(const char* optName, const char* arg, int optVal)
     {
             // case 'x':
             // doSomething();
+            // if (error) return false;
             // return true;
 
         default:
-            return false;
+            break;
     }
 
-    return false;
+    // It's OK if an arg is unhandled, as it may just be a flag set automatically
+    return true;
 }
 
 /**
@@ -601,7 +603,6 @@ bool emuParseArgs(int argc, char** argv)
         else if (optVal == ':')
         {
             // Unknown argument, print custom error message
-            // (Not In Use)
             printf("%1$s: unrecognized option '%3$s'\nTry `%2$s --help` or `%2$s --usage` for more\ninformation.\n",
                    executableName, prettyExecutableName, optarg);
         }
@@ -673,10 +674,12 @@ bool emuParseArgs(int argc, char** argv)
 
         if (optKey == '?')
         {
+            // Error message was already printed, just return false
             return false;
         }
         else if (optKey == 'h')
         {
+            // Special handling
             printHelp(prettyExecutableName);
             return false;
         }

--- a/emulator/src/extensions/emu_args.c
+++ b/emulator/src/extensions/emu_args.c
@@ -279,6 +279,9 @@ static void printUsage(const char* progName)
 
     col += printf("Usage: %s", progName);
 
+    // Do this as 2 steps to keep the code shorter
+    // First step: We build the short-options string out, then print it
+    // Second step: We print out each argument's long options
     for (uint8_t step = 0; step < 2; step++)
     {
         const optDoc_t* end = (argDocs + ARRAY_SIZE(argDocs));
@@ -288,17 +291,21 @@ static void printUsage(const char* progName)
 
             if (step == 0)
             {
+                // Just build up the short-opt string
                 if (doc->shortOpt)
                 {
+                    // Use the short-opt from the docs if we have it
                     *(shortOut++) = doc->shortOpt;
                 }
                 else if (option && option->val && option->val > ' ' && option->val <= '~')
                 {
+                    // Otherwise, check if the option was found and has a printable val.
                     *(shortOut++) = option->val;
                 }
             }
             else
             {
+                // Print out the long-opt string
                 bool arg         = false;
                 bool argOptional = false;
 
@@ -333,12 +340,14 @@ static void printUsage(const char* progName)
 
         if (step == 0)
         {
+            // Print out the short-opt string we just finished building
             *(shortOut) = '\0';
             snprintf(buffer, sizeof(buffer) - 1, " [-%s]", shortOpts);
             printColWordWrap(buffer, &col, HELP_USAGE_COL, HELP_WRAP_COL);
         }
         else
         {
+            // Print a line at the end of the usage
             printf("\n");
         }
     }
@@ -488,6 +497,7 @@ static void printColWordWrap(const char* text, int* col, int startCol, int wrapC
             }
         }
 
+        // Handle embedded newlines here so we can indent properly
         if (*ptr == '\n')
         {
             // Newline!
@@ -497,28 +507,35 @@ static void printColWordWrap(const char* text, int* col, int startCol, int wrapC
             continue;
         }
 
+        // Find the next space in the string
         nextSpace = strchr(ptr, ' ') - ptr;
 
+        // Copy a chunk of text into our buffer
         strncpy(buf, ptr, sizeof(buf) - 1);
         buf[sizeof(buf) - 1] = '\0';
 
+        // Worst-case, break the string at the end of the buffer
         nextBreak = strlen(buf);
 
         if (nextSpace >= 0 && nextSpace < nextBreak)
         {
+            // The next space is before the buffer end, so end right after that
             nextBreak = nextSpace + 1;
         }
 
         buf[nextBreak] = '\0';
 
+        // Check if the remaining string is too long to fit without a force-break
         if (startCol + strlen(buf) > wrapCol)
         {
+            // It is, so force-break it
             while ((*col) + strlen(buf) > wrapCol)
             {
                 buf[--nextBreak] = '\0';
             }
         }
 
+        // Now the string won't fit or we're out of buffer, so wrap
         if ((*col) + strlen(buf) > wrapCol || nextBreak == 0)
         {
             // Wrap!
@@ -528,6 +545,7 @@ static void printColWordWrap(const char* text, int* col, int startCol, int wrapC
             continue;
         }
 
+        // Actually print out the buffer and move the text pointer
         *col += printf("%s", buf);
         ptr += nextBreak;
     }

--- a/emulator/src/extensions/emu_args.c
+++ b/emulator/src/extensions/emu_args.c
@@ -2,15 +2,58 @@
 // Includes
 //==============================================================================
 
-#include <errno.h>
-#include <argp.h>
+// Includes mostly for getopt
+#include <stdio.h>
+#include <string.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <getopt.h>
+//#include "getopt_win.h"
+
 #include "emu_args.h"
+#include "macros.h"
+
+//==============================================================================
+// Structs
+//==============================================================================
+
+/**
+ * @brief Struct to define an argument's help options
+ *
+ */
+typedef struct
+{
+    /**
+     * @brief The short option character for this option, or 0 if it has none
+     */
+    char shortOpt;
+
+    /**
+     * @brief The long option name for this option, or NULL if it has none
+     */
+    const char* longOpt;
+
+    /**
+     * @brief If this option has a parameter, the documentation for it
+     */
+    const char* argDoc;
+
+    /**
+     * @brief The description of this option that will be shown in the help message
+     */
+    const char* doc;
+} optDoc_t;
 
 //==============================================================================
 // Function Prototypes
 //==============================================================================
 
-static error_t parseOpt(int key, char* arg, struct argp_state* state);
+static void printHelp(const char* progName);
+static void printUsage(const char* progName);
+static const optDoc_t* findOptDoc(char shortOpt, const char* longOpt);
+static const struct option* findOption(char shortOpt, const char* longOpt);
+static void getOptionsStr(char* buffer, int buflen);
+static void printColWordWrap(const char* text, int *col, int startCol, int wrapCol);
 
 //==============================================================================
 // Variables
@@ -30,57 +73,461 @@ emuArgs_t emulatorArgs = {
     .emulateTouch = false,
 };
 
-static const char doc[] = "Emulates a swadge";
+static const char mainDoc[] = "Emulates a swadge";
+
+static const char argFullscreen[] = "fullscreen";
+static const char argHideLeds[]   = "hide-leds";
+static const char argTouch[]      = "touch";
+static const char argHelp[]       = "help";
+static const char argUsage[]      = "usage";
 
 // clang-format off
-static const struct argp_option options[] =
+static const struct option options[] =
 {
-    { "fullscreen", 'f', 0, 0, "Open in fullscreen mode" },
-    { "hide-leds",  'l', 0, 0, "Don't draw simulated LEDs next to the display" },
-    { "touch",      't', 0, 0, "Simulate touch sensor readings with a virtual touchpad" },
+    { argFullscreen, no_argument, (int*)&emulatorArgs.fullscreen,   true },
+    { argHideLeds,   no_argument, (int*)&emulatorArgs.hideLeds,     true },
+    { argTouch,      no_argument, (int*)&emulatorArgs.emulateTouch, true },
+    { argHelp,       no_argument, NULL,                             'h'  },
+    { argUsage,      no_argument, NULL,                             0    },
+
     {0},
 };
 // clang-format on
 
-static struct argp argp = {options, parseOpt, NULL, doc};
+/**
+ * @brief Documentation strings for all options
+ *
+ */
+static const optDoc_t argDocs[] =
+{
+    { 'f', argFullscreen, NULL, "Open in fullscreen mode" },
+    {  0,  argHideLeds,   NULL, "Don't draw simulated LEDs next to the display" },
+    { 't', argTouch,      NULL, "Simulate touch sensor readings with a virtual touchpad" },
+    { 'h', argHelp,       NULL, "Give this help list" },
+    {  0,  argUsage,      NULL, "Give a short usage message" },
+};
 
 //==============================================================================
 // Functions
 //==============================================================================
 
-static error_t parseOpt(int key, char* arg, struct argp_state* state)
+/*Usage: swadge_emulator [OPTION...]
+Emulates a swadge
+
+  -f, --fullscreen           Open in fullscreen mode
+  -l, --hide-leds            Don't draw simulated LEDs next to the display
+  -t, --touch                Simulate touch sensor readings with a virtual
+                             touchpads
+  -?, --help                 Give this help list
+      --usage                Give a short usage message
+*/
+
+static void printHelp(const char* progName)
 {
-    switch (key)
+    int shortCol = 1;
+    int longCol = 5;
+    int textCol = 29;
+    int margin = 80;
+
+    printf("Usage: %s [OPTION...]\n%s\n", progName, mainDoc);
+
+#define INDENT(COLNUM) do { putchar(' '); } while (++col < COLNUM)
+
+    const optDoc_t* end = (argDocs + ARRAY_SIZE(argDocs));
+    for (const optDoc_t* doc = argDocs; doc != end; doc++)
     {
-        case 'f':
+        int col = 0;
+        const struct option* option = findOption(doc->shortOpt, doc->longOpt);
+        bool arg = false;
+        bool argOptional = false;
+
+        // option should never be NULL, but might as well check
+        if (NULL != option)
         {
-            // Fullscreen
-            emulatorArgs.fullscreen = true;
-            break;
+            if (option->has_arg == required_argument)
+            {
+                arg = true;
+            }
+            else if (option->has_arg == optional_argument)
+            {
+                arg = true;
+                argOptional = true;
+            }
         }
 
-        case 'l':
+        if (doc->shortOpt)
         {
-            // Hide LEDs
-            emulatorArgs.hideLeds = true;
-            break;
+            INDENT(shortCol);
+            col += printf("-%c,", doc->shortOpt);
         }
 
-        case 't':
+        if (doc->longOpt)
         {
-            // Touchpad
-            emulatorArgs.emulateTouch = true;
-            break;
+            INDENT(longCol);
+            col += printf("--%s", doc->longOpt);
+        }
+
+        if (arg)
+        {
+            if (argOptional)
+            {
+                putchar('[');
+                col++;
+            }
+
+            if (doc->argDoc)
+            {
+                col += printf("=%s", doc->argDoc);
+            }
+            else
+            {
+                col += printf("=OPTION");
+            }
+
+            if (argOptional)
+            {
+                putchar(']');
+                col++;
+            }
+        }
+
+        if (doc->doc)
+        {
+            printColWordWrap(doc->doc, &col, textCol, margin);
+        }
+
+        putchar('\n');
+    }
+
+#undef INDENT
+}
+
+/*Usage: swadge_emulator [-flt?] [--fullscreen] [--hide-leds] [--touch] [--help]
+            [--usage]
+*/
+
+static void printUsage(const char* progName)
+{
+    char shortOpts[ARRAY_SIZE(argDocs) + 1];
+    char buffer[128];
+    char* shortOut = shortOpts;
+    int col = 0;
+
+    // Make sure it's null-terminated no matter what
+    *(shortOut) = '\0';
+
+    col += printf("Usage: %s", progName);
+
+    for (uint8_t step = 0; step < 2; step++)
+    {
+        const optDoc_t* end = (argDocs + ARRAY_SIZE(argDocs));
+        for (const optDoc_t* doc = argDocs; doc != end; doc++)
+        {
+            const struct option* option = findOption(doc->shortOpt, doc->longOpt);
+
+            if (step == 0)
+            {
+                if (doc->shortOpt)
+                {
+                    *(shortOut++) = doc->shortOpt;
+                }
+                else if (option && option->val && option->val > ' ' && option->val <= '~')
+                {
+                    *(shortOut++) = option->val;
+                }
+            }
+            else
+            {
+                snprintf(buffer, sizeof(buffer) - 1, " [--%s]", doc->longOpt);
+                printColWordWrap(buffer, &col, 12, 80);
+            }
+        }
+
+        if (step == 0)
+        {
+            *(shortOut) = '\0';
+            snprintf(buffer, sizeof(buffer) - 1, " [-%s]", shortOpts);
+            printColWordWrap(buffer, &col, 0, 80);
+        }
+        else
+        {
+            printf("\n");
+        }
+    }
+}
+
+/**
+ * @brief Finds an option's documentation info by either short or long opt
+ *
+ * NOTE: This does not perform a string comparison for longOpt, so the same constant
+ * string must be used.
+ *
+ * @param shortOpt If non-zero, any option with this short option will be returned
+ * @param longOpt If non-NULL, any option with this long option will be returned
+ * @return const optDoc_t*
+ */
+static const optDoc_t* findOptDoc(char shortOpt, const char* longOpt)
+{
+    const optDoc_t* end = (argDocs + ARRAY_SIZE(argDocs));
+    for (const optDoc_t* doc = argDocs; doc != end; doc++)
+    {
+        if ((shortOpt && doc->shortOpt == shortOpt) || (longOpt && doc->longOpt == longOpt))
+        {
+            return doc;
         }
     }
 
-    return 0;
+    return NULL;
+}
+
+/**
+ * @brief Finds an option's ::option definition by either short or long opt
+ *
+ * @param shortOpt If non-zero, any option with this short option will be returned
+ * @param longOpt If non-NULL, any option with this long option will be returned
+ * @return const struct option
+ */
+static const struct option* findOption(char shortOpt, const char* longOpt)
+{
+    const struct option* opt = options;
+
+    while (opt->name != NULL)
+    {
+        if ((opt->val > ' ' && opt->val <= '~' && opt->val == shortOpt)
+            || opt->name == longOpt)
+        {
+            return opt;
+        }
+
+        opt++;
+    }
+
+    return NULL;
+}
+
+/**
+ * @brief Write the value for the \c options argument to getopt_long()
+ *
+ * @param buffer
+ * @param buflen
+ */
+static void getOptionsStr(char* buffer, int buflen)
+{
+    // pointer to our output into buffer
+    char* out = buffer;
+
+    if (buflen == 0)
+    {
+        return;
+    }
+
+// Macro to make it easy to properly check for buffer overruns
+#define CHECK_BUFFER if (out + 1 == buffer + buflen) { break; }
+
+    // If we want to stop getopt from printing its own errors for missing args,
+    // we can add a colon to the beginning of the string:
+    // *(out++) = ':';
+    // CHECK_BUFFER
+    const optDoc_t* end = (argDocs + ARRAY_SIZE(argDocs));
+    for (const optDoc_t* doc = argDocs; doc != end; doc++)
+    {
+        const struct option* option = findOption(doc->shortOpt, doc->longOpt);
+
+        if (doc->shortOpt)
+        {
+            *(out++) = doc->shortOpt;
+            CHECK_BUFFER
+
+            // option should never be NULL, but might as well check
+            if (NULL != option)
+            {
+                if (option->has_arg == required_argument)
+                {
+                    *(out++) = ':';
+                    CHECK_BUFFER
+                }
+                else if (option->has_arg == optional_argument)
+                {
+                    // Optional arguments get two colons following
+                    *(out++) = ':';
+                    CHECK_BUFFER
+                    *(out++) = ':';
+                    CHECK_BUFFER
+                }
+            }
+        }
+    }
+
+#undef CHECK_BUFFER
+
+    *out = '\0';
+}
+
+static void printColWordWrap(const char* text, int *col, int startCol, int wrapCol)
+{
+    const char* ptr = text;
+    int nextSpace, nextBreak;
+    char buf[64];
+
+    while (*ptr)
+    {
+        while (*col < startCol)
+        {
+            putchar(' ');
+            (*col)++;
+        }
+
+        if (*ptr == '\n')
+        {
+            // Newline!
+            putchar(*(ptr++));
+            *col = 0;
+            continue;
+        }
+
+        nextSpace = strchr(ptr, ' ') - ptr;
+
+        strncpy(buf, ptr, sizeof(buf) - 1);
+        buf[sizeof(buf) - 1] = '\0';
+
+        nextBreak = strlen(buf);
+
+        if (nextSpace >= 0 && nextSpace < nextBreak)
+        {
+            nextBreak = nextSpace + 1;
+        }
+
+        buf[nextBreak] = '\0';
+
+        if (startCol + strlen(buf) > wrapCol)
+        {
+            while ((*col) + strlen(buf) > wrapCol)
+            {
+                buf[--nextBreak] = '\0';
+            }
+        }
+
+        if ((*col) + strlen(buf) > wrapCol || nextBreak == 0)
+        {
+            putchar('\n');
+            *col = 0;
+            continue;
+        }
+
+        *col += printf("%s", buf);
+        ptr += nextBreak;
+    }
 }
 
 bool emuParseArgs(int argc, char** argv)
 {
-    // Pass nothing to input because we just have a static args struct
-    // If argp_parse returns non-zero there's an error
-    // So, return true as long as it's zero
-    return (0 == argp_parse(&argp, argc, argv, 0, 0, NULL));
+    const char* executableName = *argv;
+    const char* prettyExecutableName = executableName + strlen(executableName);
+
+    // Prettify the executable name by working backwards to strip everything
+    //  before the first slash or backslash
+    while (prettyExecutableName > executableName
+           && *(prettyExecutableName - 1) != '/'
+           && *(prettyExecutableName - 1) != '\\')
+    {
+        --prettyExecutableName;
+    }
+
+    // Get a buffer big enough to hold all possible option chars
+    char shortOpts[ARRAY_SIZE(options) * 2 + 1];
+    *shortOpts = '\0';
+
+    // Generate the short-option string that getopt wants from our own doc struct
+    getOptionsStr(shortOpts, sizeof(shortOpts));
+
+    while (true)
+    {
+        int optIndex = -1;
+        int optVal = getopt_long(argc, argv, shortOpts, options, &optIndex);
+        const struct option* option = NULL;
+
+        if (optVal < 0)
+        {
+            // No more options
+            break;
+        }
+        else if (optVal == '?')
+        {
+            // Handle unknown argument
+            //exit(1);
+            return false;
+        }
+        else if (optVal == ':')
+        {
+            // Unknown argument, print custom error message
+            // (Not In Use)
+            printf("%1$s: unrecognized option '%3$s'\nTry `%2$s --help` or `%2$s --usage` for more\ninformation.\n",
+                   executableName, prettyExecutableName, optarg);
+        }
+
+        // This was a short option,
+        if (optIndex != -1)
+        {
+            option = options + optIndex;
+        }
+
+        const optDoc_t* optDoc = findOptDoc(optVal, option ? option->name : NULL);
+
+        if (NULL == option && optVal != 0)
+        {
+            // Try to find an option with the short-option
+            option = findOption(optVal, optDoc ? optDoc->longOpt : NULL);
+
+            if (NULL != option)
+            {
+                if (NULL != option->flag)
+                {
+                    // A long-opt matching this short-option was found
+                    //
+                    // Do what getopt would  have done for the long opt:
+                    // Set the flag to the option val
+                    // This we we don't need to handle this manually anyway just for the short opt
+                    *(option->flag) = option->val;
+                }
+            }
+        }
+
+        // Ok, now for the case of an option which has no short-opt in the getopt options struct,
+        // but we have assigned one with the optDocs. So, we should... if we have a short opt,
+        // look for a long opt which also has that option
+        // and, if the option has a non-null flag, set that to the value.
+
+        int optKey = optVal;
+
+        if (optVal == 0)
+        {
+            // This option has no short opt, or at least is being called by its long opt
+            // Let's... see if there's anything else we can do.
+            if (NULL != optDoc && optDoc->shortOpt > 0)
+            {
+                // The optDocs have a short option that the getopt options did not!
+                // So, replace optVal with that to make processing easier
+                optKey = optDoc->shortOpt;
+            }
+            else
+            {
+                // There is no optDoc or it has no shortOpt
+                // So, let's... just use the string constant pointer. It's fine.
+                optKey = option ? (int)option->name : '?';
+            }
+        }
+
+        if (optKey == argUsage)
+        {
+            printUsage(prettyExecutableName);
+            return false;
+        }
+        else if (optKey == 'h')
+        {
+            printHelp(prettyExecutableName);
+            return false;
+        }
+    }
+
+    return true;
 }

--- a/emulator/src/extensions/emu_args.c
+++ b/emulator/src/extensions/emu_args.c
@@ -585,6 +585,7 @@ bool emuParseArgs(int argc, char** argv)
         int optVal                  = getopt_long(argc, argv, shortOpts, options, &optIndex);
         const struct option* option = NULL;
         const char* optName         = NULL;
+        const char* optArg          = optarg;
 
         if (optVal < 0)
         {
@@ -638,6 +639,14 @@ bool emuParseArgs(int argc, char** argv)
             optName = optDoc->longOpt;
         }
 
+        if(!optArg
+           && NULL != argv[optind]
+           && '-' != *(argv[optind]))
+        {
+            // This makes optional arguments work even if you don't connect them with the '='
+           optArg = argv[optind++];
+        }
+
         // Ok, now for the case of an option which has no short-opt in the getopt options struct,
         // but we have assigned one with the optDocs. So, we should... if we have a short opt,
         // look for a long opt which also has that option
@@ -677,7 +686,7 @@ bool emuParseArgs(int argc, char** argv)
             return false;
         }
 
-        if (!handleArgument(optName ? optName : NULL, optarg, optKey))
+        if (!handleArgument(optName ? optName : NULL, optArg, optKey))
         {
             // handleArgument() returned error, so should we
             return false;

--- a/emulator/src/extensions/emu_args.c
+++ b/emulator/src/extensions/emu_args.c
@@ -7,8 +7,8 @@
 #include <string.h>
 #include <stdbool.h>
 #include <stdint.h>
-#include <getopt.h>
-//#include "getopt_win.h"
+//#include <getopt.h>
+#include "getopt_win.h"
 
 #include "emu_args.h"
 #include "macros.h"

--- a/emulator/src/extensions/emu_args.c
+++ b/emulator/src/extensions/emu_args.c
@@ -7,7 +7,6 @@
 #include <string.h>
 #include <stdbool.h>
 #include <stdint.h>
-//#include <getopt.h>
 #include "getopt_win.h"
 
 #include "emu_args.h"

--- a/emulator/src/getopt_win.h
+++ b/emulator/src/getopt_win.h
@@ -1,0 +1,649 @@
+#ifndef __GETOPT_H__
+/**
+ * DISCLAIMER
+ * This file is part of the mingw-w64 runtime package.
+ *
+ * The mingw-w64 runtime package and its code is distributed in the hope that it
+ * will be useful but WITHOUT ANY WARRANTY.  ALL WARRANTIES, EXPRESSED OR
+ * IMPLIED ARE HEREBY DISCLAIMED.  This includes but is not limited to
+ * warranties of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ */
+ /*
+ * Copyright (c) 2002 Todd C. Miller <Todd.Miller@courtesan.com>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *
+ * Sponsored in part by the Defense Advanced Research Projects
+ * Agency (DARPA) and Air Force Research Laboratory, Air Force
+ * Materiel Command, USAF, under agreement number F39502-99-1-0512.
+ */
+/*-
+ * Copyright (c) 2000 The NetBSD Foundation, Inc.
+ * All rights reserved.
+ *
+ * This code is derived from software contributed to The NetBSD Foundation
+ * by Dieter Baron and Thomas Klausner.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE NETBSD FOUNDATION, INC. AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE FOUNDATION OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#define __GETOPT_H__
+
+/* All the headers include this file. */
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdarg.h>
+#include <stdio.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define	REPLACE_GETOPT		/* use this getopt as the system getopt(3) */
+
+#ifdef REPLACE_GETOPT
+int	opterr;// = 1;		/* if error message should be printed */
+int	optind;// = 1;		/* index into parent argv vector */
+int	optopt;// = '?';		/* character checked for validity */
+#undef	optreset		/* see getopt.h */
+#define	optreset		__mingw_optreset
+int	optreset;		/* reset getopt */
+char    *optarg;		/* argument associated with option */
+#endif
+
+//extern int optind;		/* index of first non-option in argv      */
+//extern int optopt;		/* single option character, as parsed     */
+//extern int opterr;		/* flag to enable built-in diagnostics... */
+//				/* (user may set to zero, to suppress)    */
+//
+//extern char *optarg;		/* pointer to argument of current option  */
+
+#define PRINT_ERROR	((opterr) && (*options != ':'))
+
+#define FLAG_PERMUTE	0x01	/* permute non-options to the end of argv */
+#define FLAG_ALLARGS	0x02	/* treat non-options as args to option "-1" */
+#define FLAG_LONGONLY	0x04	/* operate as getopt_long_only */
+
+/* return values */
+#define	BADCH		(int)'?'
+#define	BADARG		((*options == ':') ? (int)':' : (int)'?')
+#define	INORDER 	(int)1
+
+#ifndef __CYGWIN__
+#define __progname __argv[0]
+#else
+extern char __declspec(dllimport) *__progname;
+#endif
+
+#ifdef __CYGWIN__
+static char EMSG[] = "";
+#else
+#define	EMSG		""
+#endif
+
+static int getopt_internal(int nargc, char * const *nargv, const char *options,
+	const struct option *long_options, int *idx, int flags);
+static int parse_long_options(char * const *nargv, const char *options,
+	const struct option *long_options, int *idx, int short_too);
+static int gcd(int, int);
+static void permute_args(int, int, int, char * const *);
+
+static char *place = EMSG; /* option letter processing */
+
+/* XXX: set optreset to 1 rather than these two */
+static int nonopt_start = -1; /* first non option argument (for permute) */
+static int nonopt_end = -1;   /* first option after non options (for permute) */
+
+/* Error messages */
+static const char recargchar[] = "option requires an argument -- %c";
+static const char recargstring[] = "option requires an argument -- %s";
+static const char ambig[] = "ambiguous option -- %.*s";
+static const char noarg[] = "option doesn't take an argument -- %.*s";
+static const char illoptchar[] = "unknown option -- %c";
+static const char illoptstring[] = "unknown option -- %s";
+
+static void
+_vwarnx(const char *fmt,va_list ap)
+{
+  (void)fprintf(stderr,"%s: ",__progname);
+  if (fmt != NULL)
+    (void)vfprintf(stderr,fmt,ap);
+  (void)fprintf(stderr,"\n");
+}
+
+static void
+warnx(const char *fmt,...)
+{
+  va_list ap;
+  va_start(ap,fmt);
+  _vwarnx(fmt,ap);
+  va_end(ap);
+}
+
+/*
+ * Compute the greatest common divisor of a and b.
+ */
+static int
+gcd(int a, int b)
+{
+	int c;
+
+	c = a % b;
+	while (c != 0) {
+		a = b;
+		b = c;
+		c = a % b;
+	}
+
+	return (b);
+}
+
+/*
+ * Exchange the block from nonopt_start to nonopt_end with the block
+ * from nonopt_end to opt_end (keeping the same order of arguments
+ * in each block).
+ */
+static void
+permute_args(int panonopt_start, int panonopt_end, int opt_end,
+	char * const *nargv)
+{
+	int cstart, cyclelen, i, j, ncycle, nnonopts, nopts, pos;
+	char *swap;
+
+	/*
+	 * compute lengths of blocks and number and size of cycles
+	 */
+	nnonopts = panonopt_end - panonopt_start;
+	nopts = opt_end - panonopt_end;
+	ncycle = gcd(nnonopts, nopts);
+	cyclelen = (opt_end - panonopt_start) / ncycle;
+
+	for (i = 0; i < ncycle; i++) {
+		cstart = panonopt_end+i;
+		pos = cstart;
+		for (j = 0; j < cyclelen; j++) {
+			if (pos >= panonopt_end)
+				pos -= nnonopts;
+			else
+				pos += nopts;
+			swap = nargv[pos];
+			/* LINTED const cast */
+			((char **) nargv)[pos] = nargv[cstart];
+			/* LINTED const cast */
+			((char **)nargv)[cstart] = swap;
+		}
+	}
+}
+
+#ifdef REPLACE_GETOPT
+/*
+ * getopt --
+ *	Parse argc/argv argument vector.
+ *
+ * [eventually this will replace the BSD getopt]
+ */
+static int
+getopt(int nargc, char * const *nargv, const char *options)
+{
+
+	/*
+	 * We don't pass FLAG_PERMUTE to getopt_internal() since
+	 * the BSD getopt(3) (unlike GNU) has never done this.
+	 *
+	 * Furthermore, since many privileged programs call getopt()
+	 * before dropping privileges it makes sense to keep things
+	 * as simple (and bug-free) as possible.
+	 */
+	return (getopt_internal(nargc, nargv, options, NULL, NULL, 0));
+}
+#endif /* REPLACE_GETOPT */
+
+//extern int getopt(int nargc, char * const *nargv, const char *options);
+
+#ifdef _BSD_SOURCE
+/*
+ * BSD adds the non-standard `optreset' feature, for reinitialisation
+ * of `getopt' parsing.  We support this feature, for applications which
+ * proclaim their BSD heritage, before including this header; however,
+ * to maintain portability, developers are advised to avoid it.
+ */
+# define optreset  __mingw_optreset
+extern int optreset;
+#endif
+#ifdef __cplusplus
+}
+#endif
+/*
+ * POSIX requires the `getopt' API to be specified in `unistd.h';
+ * thus, `unistd.h' includes this header.  However, we do not want
+ * to expose the `getopt_long' or `getopt_long_only' APIs, when
+ * included in this manner.  Thus, close the standard __GETOPT_H__
+ * declarations block, and open an additional __GETOPT_LONG_H__
+ * specific block, only when *not* __UNISTD_H_SOURCED__, in which
+ * to declare the extended API.
+ */
+#endif /* !defined(__GETOPT_H__) */
+
+#if !defined(__UNISTD_H_SOURCED__) && !defined(__GETOPT_LONG_H__)
+#define __GETOPT_LONG_H__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct option		/* specification for a long form option...	*/
+{
+  const char *name;		/* option name, without leading hyphens */
+  int         has_arg;		/* does it take an argument?		*/
+  int        *flag;		/* where to save its status, or NULL	*/
+  int         val;		/* its associated status value		*/
+};
+
+enum    		/* permitted values for its `has_arg' field...	*/
+{
+  no_argument = 0,      	/* option never takes an argument	*/
+  required_argument,		/* option always requires an argument	*/
+  optional_argument		/* option may take an argument		*/
+};
+
+/*
+ * parse_long_options --
+ *	Parse long options in argc/argv argument vector.
+ * Returns -1 if short_too is set and the option does not match long_options.
+ */
+static int
+parse_long_options(char * const *nargv, const char *options,
+	const struct option *long_options, int *idx, int short_too)
+{
+	char *current_argv, *has_equal;
+	size_t current_argv_len;
+	int i, ambiguous, match;
+
+#define IDENTICAL_INTERPRETATION(_x, _y)                                \
+	(long_options[(_x)].has_arg == long_options[(_y)].has_arg &&    \
+	 long_options[(_x)].flag == long_options[(_y)].flag &&          \
+	 long_options[(_x)].val == long_options[(_y)].val)
+
+	current_argv = place;
+	match = -1;
+	ambiguous = 0;
+
+	optind++;
+
+	if ((has_equal = strchr(current_argv, '=')) != NULL) {
+		/* argument found (--option=arg) */
+		current_argv_len = has_equal - current_argv;
+		has_equal++;
+	} else
+		current_argv_len = strlen(current_argv);
+
+	for (i = 0; long_options[i].name; i++) {
+		/* find matching long option */
+		if (strncmp(current_argv, long_options[i].name,
+		    current_argv_len))
+			continue;
+
+		if (strlen(long_options[i].name) == current_argv_len) {
+			/* exact match */
+			match = i;
+			ambiguous = 0;
+			break;
+		}
+		/*
+		 * If this is a known short option, don't allow
+		 * a partial match of a single character.
+		 */
+		if (short_too && current_argv_len == 1)
+			continue;
+
+		if (match == -1)	/* partial match */
+			match = i;
+		else if (!IDENTICAL_INTERPRETATION(i, match))
+			ambiguous = 1;
+	}
+	if (ambiguous) {
+		/* ambiguous abbreviation */
+		if (PRINT_ERROR)
+			warnx(ambig, (int)current_argv_len,
+			     current_argv);
+		optopt = 0;
+		return (BADCH);
+	}
+	if (match != -1) {		/* option found */
+		if (long_options[match].has_arg == no_argument
+		    && has_equal) {
+			if (PRINT_ERROR)
+				warnx(noarg, (int)current_argv_len,
+				     current_argv);
+			/*
+			 * XXX: GNU sets optopt to val regardless of flag
+			 */
+			if (long_options[match].flag == NULL)
+				optopt = long_options[match].val;
+			else
+				optopt = 0;
+			return (BADARG);
+		}
+		if (long_options[match].has_arg == required_argument ||
+		    long_options[match].has_arg == optional_argument) {
+			if (has_equal)
+				optarg = has_equal;
+			else if (long_options[match].has_arg ==
+			    required_argument) {
+				/*
+				 * optional argument doesn't use next nargv
+				 */
+				optarg = nargv[optind++];
+			}
+		}
+		if ((long_options[match].has_arg == required_argument)
+		    && (optarg == NULL)) {
+			/*
+			 * Missing argument; leading ':' indicates no error
+			 * should be generated.
+			 */
+			if (PRINT_ERROR)
+				warnx(recargstring,
+				    current_argv);
+			/*
+			 * XXX: GNU sets optopt to val regardless of flag
+			 */
+			if (long_options[match].flag == NULL)
+				optopt = long_options[match].val;
+			else
+				optopt = 0;
+			--optind;
+			return (BADARG);
+		}
+	} else {			/* unknown option */
+		if (short_too) {
+			--optind;
+			return (-1);
+		}
+		if (PRINT_ERROR)
+			warnx(illoptstring, current_argv);
+		optopt = 0;
+		return (BADCH);
+	}
+	if (idx)
+		*idx = match;
+	if (long_options[match].flag) {
+		*long_options[match].flag = long_options[match].val;
+		return (0);
+	} else
+		return (long_options[match].val);
+#undef IDENTICAL_INTERPRETATION
+}
+
+/*
+ * getopt_internal --
+ *	Parse argc/argv argument vector.  Called by user level routines.
+ */
+static int
+getopt_internal(int nargc, char * const *nargv, const char *options,
+	const struct option *long_options, int *idx, int flags)
+{
+	char *oli;				/* option letter list index */
+	int optchar, short_too;
+	static int posixly_correct = -1;
+
+	if (options == NULL)
+		return (-1);
+
+	/*
+	 * XXX Some GNU programs (like cvs) set optind to 0 instead of
+	 * XXX using optreset.  Work around this braindamage.
+	 */
+	if (optind == 0)
+		optind = optreset = 1;
+
+	/*
+	 * Disable GNU extensions if POSIXLY_CORRECT is set or options
+	 * string begins with a '+'.
+	 *
+	 * CV, 2009-12-14: Check POSIXLY_CORRECT anew if optind == 0 or
+	 *                 optreset != 0 for GNU compatibility.
+	 */
+	if (posixly_correct == -1 || optreset != 0)
+		posixly_correct = (getenv("POSIXLY_CORRECT") != NULL);
+	if (*options == '-')
+		flags |= FLAG_ALLARGS;
+	else if (posixly_correct || *options == '+')
+		flags &= ~FLAG_PERMUTE;
+	if (*options == '+' || *options == '-')
+		options++;
+
+	optarg = NULL;
+	if (optreset)
+		nonopt_start = nonopt_end = -1;
+start:
+	if (optreset || !*place) {		/* update scanning pointer */
+		optreset = 0;
+		if (optind >= nargc) {          /* end of argument vector */
+			place = EMSG;
+			if (nonopt_end != -1) {
+				/* do permutation, if we have to */
+				permute_args(nonopt_start, nonopt_end,
+				    optind, nargv);
+				optind -= nonopt_end - nonopt_start;
+			}
+			else if (nonopt_start != -1) {
+				/*
+				 * If we skipped non-options, set optind
+				 * to the first of them.
+				 */
+				optind = nonopt_start;
+			}
+			nonopt_start = nonopt_end = -1;
+			return (-1);
+		}
+		if (*(place = nargv[optind]) != '-' ||
+		    (place[1] == '\0' && strchr(options, '-') == NULL)) {
+			place = EMSG;		/* found non-option */
+			if (flags & FLAG_ALLARGS) {
+				/*
+				 * GNU extension:
+				 * return non-option as argument to option 1
+				 */
+				optarg = nargv[optind++];
+				return (INORDER);
+			}
+			if (!(flags & FLAG_PERMUTE)) {
+				/*
+				 * If no permutation wanted, stop parsing
+				 * at first non-option.
+				 */
+				return (-1);
+			}
+			/* do permutation */
+			if (nonopt_start == -1)
+				nonopt_start = optind;
+			else if (nonopt_end != -1) {
+				permute_args(nonopt_start, nonopt_end,
+				    optind, nargv);
+				nonopt_start = optind -
+				    (nonopt_end - nonopt_start);
+				nonopt_end = -1;
+			}
+			optind++;
+			/* process next argument */
+			goto start;
+		}
+		if (nonopt_start != -1 && nonopt_end == -1)
+			nonopt_end = optind;
+
+		/*
+		 * If we have "-" do nothing, if "--" we are done.
+		 */
+		if (place[1] != '\0' && *++place == '-' && place[1] == '\0') {
+			optind++;
+			place = EMSG;
+			/*
+			 * We found an option (--), so if we skipped
+			 * non-options, we have to permute.
+			 */
+			if (nonopt_end != -1) {
+				permute_args(nonopt_start, nonopt_end,
+				    optind, nargv);
+				optind -= nonopt_end - nonopt_start;
+			}
+			nonopt_start = nonopt_end = -1;
+			return (-1);
+		}
+	}
+
+	/*
+	 * Check long options if:
+	 *  1) we were passed some
+	 *  2) the arg is not just "-"
+	 *  3) either the arg starts with -- we are getopt_long_only()
+	 */
+	if (long_options != NULL && place != nargv[optind] &&
+	    (*place == '-' || (flags & FLAG_LONGONLY))) {
+		short_too = 0;
+		if (*place == '-')
+			place++;		/* --foo long option */
+		else if (*place != ':' && strchr(options, *place) != NULL)
+			short_too = 1;		/* could be short option too */
+
+		optchar = parse_long_options(nargv, options, long_options,
+		    idx, short_too);
+		if (optchar != -1) {
+			place = EMSG;
+			return (optchar);
+		}
+	}
+
+	if ((optchar = (int)*place++) == (int)':' ||
+	    (optchar == (int)'-' && *place != '\0') ||
+	    (oli = (char*)strchr(options, optchar)) == NULL) {
+		/*
+		 * If the user specified "-" and  '-' isn't listed in
+		 * options, return -1 (non-option) as per POSIX.
+		 * Otherwise, it is an unknown option character (or ':').
+		 */
+		if (optchar == (int)'-' && *place == '\0')
+			return (-1);
+		if (!*place)
+			++optind;
+		if (PRINT_ERROR)
+			warnx(illoptchar, optchar);
+		optopt = optchar;
+		return (BADCH);
+	}
+	if (long_options != NULL && optchar == 'W' && oli[1] == ';') {
+		/* -W long-option */
+		if (*place)			/* no space */
+			/* NOTHING */;
+		else if (++optind >= nargc) {	/* no arg */
+			place = EMSG;
+			if (PRINT_ERROR)
+				warnx(recargchar, optchar);
+			optopt = optchar;
+			return (BADARG);
+		} else				/* white space */
+			place = nargv[optind];
+		optchar = parse_long_options(nargv, options, long_options,
+		    idx, 0);
+		place = EMSG;
+		return (optchar);
+	}
+	if (*++oli != ':') {			/* doesn't take argument */
+		if (!*place)
+			++optind;
+	} else {				/* takes (optional) argument */
+		optarg = NULL;
+		if (*place)			/* no white space */
+			optarg = place;
+		else if (oli[1] != ':') {	/* arg not optional */
+			if (++optind >= nargc) {	/* no arg */
+				place = EMSG;
+				if (PRINT_ERROR)
+					warnx(recargchar, optchar);
+				optopt = optchar;
+				return (BADARG);
+			} else
+				optarg = nargv[optind];
+		}
+		place = EMSG;
+		++optind;
+	}
+	/* dump back option letter */
+	return (optchar);
+}
+
+/*
+ * getopt_long --
+ *	Parse argc/argv argument vector.
+ */
+static int
+getopt_long(int nargc, char * const *nargv, const char *options,
+    const struct option *long_options, int *idx)
+{
+
+	return (getopt_internal(nargc, nargv, options, long_options, idx,
+	    FLAG_PERMUTE));
+}
+
+/*
+ * getopt_long_only --
+ *	Parse argc/argv argument vector.
+ */
+static int
+getopt_long_only(int nargc, char * const *nargv, const char *options,
+    const struct option *long_options, int *idx)
+{
+
+	return (getopt_internal(nargc, nargv, options, long_options, idx,
+	    FLAG_PERMUTE|FLAG_LONGONLY));
+}
+
+//extern int getopt_long(int nargc, char * const *nargv, const char *options,
+//    const struct option *long_options, int *idx);
+//extern int getopt_long_only(int nargc, char * const *nargv, const char *options,
+//    const struct option *long_options, int *idx);
+/*
+ * Previous MinGW implementation had...
+ */
+#ifndef HAVE_DECL_GETOPT
+/*
+ * ...for the long form API only; keep this for compatibility.
+ */
+# define HAVE_DECL_GETOPT	1
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* !defined(__UNISTD_H_SOURCED__) && !defined(__GETOPT_LONG_H__) */

--- a/emulator/src/getopt_win.h
+++ b/emulator/src/getopt_win.h
@@ -99,18 +99,13 @@ char    *optarg;		/* argument associated with option */
 #define	BADARG		((*options == ':') ? (int)':' : (int)'?')
 #define	INORDER 	(int)1
 
-#ifndef __CYGWIN__
-#define __progname __argv[0]
-#else
-extern char __declspec(dllimport) *__progname;
-#endif
-
 #ifdef __CYGWIN__
 static char EMSG[] = "";
 #else
 #define	EMSG		""
 #endif
 
+struct option;
 static int getopt_internal(int nargc, char * const *nargv, const char *options,
 	const struct option *long_options, int *idx, int flags);
 static int parse_long_options(char * const *nargv, const char *options,
@@ -135,7 +130,6 @@ static const char illoptstring[] = "unknown option -- %s";
 static void
 _vwarnx(const char *fmt,va_list ap)
 {
-  (void)fprintf(stderr,"%s: ",__progname);
   if (fmt != NULL)
     (void)vfprintf(stderr,fmt,ap);
   (void)fprintf(stderr,"\n");

--- a/makefile
+++ b/makefile
@@ -328,6 +328,7 @@ CPPCHECK_DIRS= \
 
 CPPCHECK_IGNORE= \
 	emulator/src/rawdraw_sf.h \
+	emulator/src/getopt_win.h \
 	emulator/sound \
 	emulator/src/components/hdw-nvs/cJSON.c \
 	emulator/src/components/hdw-nvs/cJSON.h \

--- a/makefile
+++ b/makefile
@@ -19,7 +19,11 @@ endif
 # Programs to use
 ################################################################################
 
-CC = gcc
+ifeq ($(HOST_OS),Windows)
+	CC = x86_64-w64-mingw32-gcc.exe
+else ifeq ($(HOST_OS),Linux)
+	CC = gcc
+endif
 
 FIND:=find
 ifeq ($(HOST_OS),Windows)
@@ -166,10 +170,6 @@ DEFINES_LIST = \
 	_POSIX_READER_WRITER_LOCKS \
 	CFG_TUSB_MCU=OPT_MCU_ESP32S2
 
-ifeq ($(HOST_OS),Windows)
-	DEFINES_LIST += WINDOWS
-endif
-
 # Extra defines
 DEFINES_LIST += \
 	EMULATOR=1 \
@@ -196,7 +196,7 @@ OBJECTS = $(patsubst %.c, $(OBJ_DIR)/%.o, $(SOURCES))
 # This is a list of libraries to include. Order doesn't matter
 
 ifeq ($(HOST_OS),Windows)
-    LIBS = opengl32 gdi32 user32 winmm WSock32 argp
+    LIBS = opengl32 gdi32 user32 winmm WSock32
 endif
 ifeq ($(HOST_OS),Linux)
     LIBS = m X11 asound pulse rt GL GLX pthread Xext Xinerama

--- a/makefile
+++ b/makefile
@@ -42,7 +42,7 @@ SRC_DIRS = $(shell $(FIND) $(SRC_DIRS_RECURSIVE) -type d) $(SRC_DIRS_FLAT)
 SOURCES   = $(shell $(FIND) $(SRC_DIRS) -maxdepth 1 -iname "*.[c]") $(SRC_FILES)
 
 # The emulator doesn't build components, but there is a target for formatting them
-ALL_FILES = $(shell $(FIND) components $(SRC_DIRS_RECURSIVE) -iname "*.[c|h]" -not -name "rawdraw_sf.h" -not -name "rawdraw_sf.h" -not -name "cJSON*")
+ALL_FILES = $(shell $(FIND) components $(SRC_DIRS_RECURSIVE) -iname "*.[c|h]" -not -name "rawdraw_sf.h" -not -name "getopt_win.h" -not -name "cJSON*")
 
 ################################################################################
 # Includes
@@ -99,7 +99,7 @@ CFLAGS_WARNINGS = \
 	-Wno-enum-conversion \
 	-Wno-error=unused-but-set-variable \
 	-Wno-old-style-declaration
-	
+
 # These are warning flags that I like
 CFLAGS_WARNINGS_EXTRA = \
 	-Wundef \


### PR DESCRIPTION
### Description

<!--- What was added and/or fixed in this pull request? -->

This adds arg parsing with a standalone `getopt_win.h` provided by @cnlohr as well as some extra code to make the help text automatically just like our dear departed argp did.

### Test Instructions

<!--- How was this tested? -->

I ran it a few times, changed around some options, things seemed mostly fine.

### Ticket Links

<!--- Link any tickets that are completed in this pull request. -->

### Readiness Checklist
- [x] I have run `make format` to format the changes (except getopt)
- [x] I have compiled the firmware and the changes have no warnings
- [x] I have compiled the emulator and the changes have no warnings (there's a couple in getopt but...)
- [x] I have run `make cppcheck` and checked that `cppcheck_result.txt` has no warnings for the changes
- [x] I have added doxygen comments to any code used by more than one Swadge mode. This includes `/*! \file` comments with Design Philosophy, Usage, and Example sections for new headers.
- [x] I have run `make docs` and checked that `doxy_warnings.txt` has no warnings for the new code
