### PR TITLE
Fuzzer Emu Extension

### DIFF
--- a/emulator/idf-inc/esp_sleep_emu.h
+++ b/emulator/idf-inc/esp_sleep_emu.h
@@ -1,0 +1,5 @@
+#pragma once
+#include "swadge2024.h"
+
+void emulatorForceSwitchToSwadgeMode(swadgeMode_t* mode);
+void emulatorSetSwadgeModeLocked(bool locked);

--- a/emulator/src/emu_main.c
+++ b/emulator/src/emu_main.c
@@ -73,6 +73,15 @@ static void plotRoundedCorners(uint32_t* bitmapDisplay, int w, int h, int r, uin
 //==============================================================================
 
 /**
+ * @brief Quits the emulator
+ *
+ */
+void emulatorQuit(void)
+{
+    isRunning = false;
+}
+
+/**
  * @brief Parse and handle command line arguments
  *
  * @param argc The number of command line arguments
@@ -113,6 +122,12 @@ int main(int argc, char** argv)
     // Call any init callbacks we may have and pass them the parsed command-line arguments
     // We also determine which extensions are enabled here, which is important for laying out the window properly
     initExtensions(&emulatorArgs);
+
+    if (!isRunning)
+    {
+        // One of the extension must have quit due to an error.
+        return 0;
+    }
 #endif
 
     // First initialize rawdraw

--- a/emulator/src/emu_main.h
+++ b/emulator/src/emu_main.h
@@ -12,3 +12,5 @@
             printf("%s is UNIMPLEMENTED\n", __func__); \
         }                                              \
     }
+
+void emulatorQuit(void);

--- a/emulator/src/extensions/emu_args.c
+++ b/emulator/src/extensions/emu_args.c
@@ -712,15 +712,18 @@ bool emuParseArgs(int argc, char** argv)
         }
         else if (optVal == '?')
         {
-            // Handle unknown argument
-            // exit(1);
+            // Unknown argument, print custom error message
+            printf("%1$s: unrecognized option '%3$s'\n\nTry `%2$s --help` or `%2$s --usage` for more\ninformation.\n",
+                   executableName, prettyExecutableName, argv[optind - 1]);
             return false;
         }
         else if (optVal == ':')
         {
-            // Unknown argument, print custom error message
-            printf("%1$s: unrecognized option '%3$s'\nTry `%2$s --help` or `%2$s --usage` for more\ninformation.\n",
-                   executableName, prettyExecutableName, optarg);
+            // Missing value, print custom error message
+            printf("%1$s: option '%3$s' missing required argument\n\nTry `%2$s --help` or `%2$s --usage` for "
+                   "more\ninformation.\n",
+                   executableName, prettyExecutableName, argv[optind - 1]);
+            return false;
         }
 
         // This was a short option,

--- a/emulator/src/extensions/emu_args.c
+++ b/emulator/src/extensions/emu_args.c
@@ -84,16 +84,16 @@ emuArgs_t emulatorArgs = {
     .fullscreen = false,
     .hideLeds   = false,
 
-    .fuzz = false,
+    .fuzz        = false,
     .fuzzButtons = false,
-    .fuzzTouch = false,
-    .fuzzMotion = false,
+    .fuzzTouch   = false,
+    .fuzzMotion  = false,
 
     .keymap = NULL,
 
     .lock = false,
 
-    .startMode = NULL,
+    .startMode      = NULL,
     .modeSwitchTime = 0,
 
     .emulateMotion      = false,
@@ -190,8 +190,8 @@ static bool handleArgument(const char* optName, const char* arg, int optVal)
     {
         // Enable Fuzz
         emulatorArgs.fuzzButtons = true;
-        emulatorArgs.fuzzTouch = true;
-        emulatorArgs.fuzzMotion = true;
+        emulatorArgs.fuzzTouch   = true;
+        emulatorArgs.fuzzMotion  = true;
         return true;
     }
     else if (argFuzzButtons == optName)
@@ -251,7 +251,7 @@ static bool handleArgument(const char* optName, const char* arg, int optVal)
     {
         if (arg)
         {
-            errno = 0;
+            errno                       = 0;
             emulatorArgs.modeSwitchTime = atol(arg);
             if (errno)
             {
@@ -756,12 +756,10 @@ bool emuParseArgs(int argc, char** argv)
             optName = optDoc->longOpt;
         }
 
-        if(!optArg
-           && NULL != argv[optind]
-           && '-' != *(argv[optind]))
+        if (!optArg && NULL != argv[optind] && '-' != *(argv[optind]))
         {
             // This makes optional arguments work even if you don't connect them with the '='
-           optArg = argv[optind++];
+            optArg = argv[optind++];
         }
 
         // Ok, now for the case of an option which has no short-opt in the getopt options struct,
@@ -855,14 +853,12 @@ static bool parseBoolArg(const char* val, bool defaultValue)
 
             default:
             {
-                if (!strncmp("off", val, MAX(2, strlen("off")))
-                    || !strncmp("disable", val, strlen(val))
+                if (!strncmp("off", val, MAX(2, strlen("off"))) || !strncmp("disable", val, strlen(val))
                     || !strncmp("without", val, MAX(5, strlen(val))))
                 {
                     return false;
                 }
-                else if (!strncmp("on", val, strlen("on"))
-                         || !strncmp("enable", val, strlen("enable"))
+                else if (!strncmp("on", val, strlen("on")) || !strncmp("enable", val, strlen("enable"))
                          || !strncmp("with", val, strlen(val)))
                 {
                     return true;

--- a/emulator/src/extensions/emu_args.h
+++ b/emulator/src/extensions/emu_args.h
@@ -32,6 +32,11 @@ typedef struct
     /// @brief Name of the keymap to use, or NULL if none
     const char* keymap;
 
+    bool lock;
+
+    const char* startMode;
+    uint32_t modeSwitchTime;
+
     bool emulateMotion;
     bool motionJitter;
     uint16_t motionJitterAmount;

--- a/emulator/src/extensions/emu_args.h
+++ b/emulator/src/extensions/emu_args.h
@@ -24,6 +24,11 @@ typedef struct
     bool fullscreen;
     bool hideLeds;
 
+    bool fuzz;
+    bool fuzzButtons;
+    bool fuzzTouch;
+    bool fuzzMotion;
+
     /// @brief Name of the keymap to use, or NULL if none
     const char* keymap;
 

--- a/emulator/src/extensions/emu_ext.c
+++ b/emulator/src/extensions/emu_ext.c
@@ -15,6 +15,7 @@
 // Extension Includes
 #include "ext_touch.h"
 #include "ext_leds.h"
+#include "ext_fuzzer.h"
 
 //==============================================================================
 // Registered Extensions
@@ -27,6 +28,7 @@
 static const emuExtension_t* registeredExtensions[] = {
     &touchEmuCallback,
     &ledEmuExtension,
+    &fuzzerEmuExtension,
 };
 
 //==============================================================================

--- a/emulator/src/extensions/emu_ext.c
+++ b/emulator/src/extensions/emu_ext.c
@@ -16,6 +16,7 @@
 #include "ext_touch.h"
 #include "ext_leds.h"
 #include "ext_fuzzer.h"
+#include "ext_modes.h"
 
 //==============================================================================
 // Registered Extensions
@@ -29,6 +30,7 @@ static const emuExtension_t* registeredExtensions[] = {
     &touchEmuCallback,
     &ledEmuExtension,
     &fuzzerEmuExtension,
+    &modesEmuExtension,
 };
 
 //==============================================================================

--- a/emulator/src/extensions/fuzzer/ext_fuzzer.c
+++ b/emulator/src/extensions/fuzzer/ext_fuzzer.c
@@ -1,0 +1,110 @@
+//==============================================================================
+// Imports
+//==============================================================================
+
+#include <stdlib.h>
+#include <stdio.h>
+
+#include "ext_fuzzer.h"
+#include "emu_args.h"
+#include "hdw-btn_emu.h"
+#include "hdw-accel_emu.h"
+
+//==============================================================================
+// Function Prototypes
+//==============================================================================
+
+static bool fuzzerInitCb(const emuArgs_t* emuArgs);
+static void fuzzerPreFrameCb(uint64_t frame);
+
+//==============================================================================
+// Structs
+//==============================================================================
+
+typedef struct
+{
+    bool buttons;
+    bool touch;
+    bool motion;
+} fuzzer_t;
+
+//==============================================================================
+// Variables
+//==============================================================================
+
+emuExtension_t fuzzerEmuExtension = {
+    .name            = "fuzzer",
+    .fnInitCb        = fuzzerInitCb,
+    .fnPreFrameCb    = fuzzerPreFrameCb,
+    .fnPostFrameCb   = NULL,
+    .fnKeyCb         = NULL,
+    .fnMouseMoveCb   = NULL,
+    .fnMouseButtonCb = NULL,
+    .fnRenderCb      = NULL,
+};
+
+static fuzzer_t fuzzer = {0};
+
+//==============================================================================
+// Functions
+//==============================================================================
+
+static bool fuzzerInitCb(const emuArgs_t* emuArgs)
+{
+    // Save the options in our own struct for convenience
+    fuzzer.buttons = emuArgs->fuzzButtons;
+    fuzzer.touch   = emuArgs->fuzzTouch;
+    fuzzer.motion  = emuArgs->fuzzMotion;
+
+    if (emuArgs->fuzz)
+    {
+        printf("\nFuzzing:\n - [%c] Buttons\n - [%c] Touch\n - [%c] Motion\n", fuzzer.buttons ? 'X' : ' ',
+               fuzzer.touch ? 'X' : ' ', fuzzer.motion ? 'X' : ' ');
+    }
+
+    return emuArgs->fuzz;
+}
+
+static void fuzzerPreFrameCb(uint64_t frame)
+{
+    if (fuzzer.buttons)
+    {
+        buttonBit_t buttonState = emulatorGetButtonState();
+
+        // Pick a random button
+        uint8_t i              = rand() % 8;
+        buttonBit_t fuzzButton = (1 << i);
+
+        // Inject the button event to flip that button's state
+        emulatorInjectButton(fuzzButton, (buttonState & fuzzButton) == 0);
+    }
+
+    if (fuzzer.touch)
+    {
+        if (0 == (rand() % 2))
+        {
+            // Set a random angle, radius (up to 1024, not 1023), and intensity value 50% of the time
+            emulatorSetTouchJoystick(rand() % 360, rand() % 1025, rand() % (1 << 18));
+        }
+        else
+        {
+            // Set no touch 50% of the time
+            emulatorSetTouchJoystick(0, 0, 0);
+        }
+    }
+
+    if (fuzzer.motion)
+    {
+        // Get the accelerometer range, once
+        static int16_t accelMin = 0, accelMax = 0;
+        if (accelMin == 0 && accelMax == 0)
+        {
+            emulatorGetAccelerometerRange(&accelMin, &accelMax);
+        }
+
+        // Set the accelerometer to 3 random readings
+        emulatorSetAccelerometer((rand() % (1 + accelMax - accelMin)) + accelMin,
+                                 (rand() % (1 + accelMax - accelMin)) + accelMin,
+                                 (rand() % (1 + accelMax - accelMin)) + accelMin);
+    }
+}

--- a/emulator/src/extensions/fuzzer/ext_fuzzer.h
+++ b/emulator/src/extensions/fuzzer/ext_fuzzer.h
@@ -1,0 +1,5 @@
+#pragma once
+
+#include "emu_ext.h"
+
+extern emuExtension_t fuzzerEmuExtension;

--- a/emulator/src/extensions/modes/ext_modes.c
+++ b/emulator/src/extensions/modes/ext_modes.c
@@ -11,8 +11,11 @@
 #include <stdlib.h>
 
 // Mode Includes
-// Quickly regenerate with:
-// grep -lirE '^extern swadgeMode_t (.*);' | grep -oE '([^/]+\.h)' | grep -v quickSettings | awk '{printf "#include \"%s\"\n",$1 }' | sort
+/*
+ Quickly regenerate with:
+   grep -lirE '^extern swadgeMode_t (.*);' | grep -oE '([^/]+\.h)'
+    | grep -v quickSettings | awk '{printf "#include \"%s\"\n",$1 }' | sort
+*/
 #include "accelTest.h"
 #include "colorchord.h"
 #include "dance.h"
@@ -27,7 +30,7 @@
 // Defines
 //==============================================================================
 
-#define ONE_SECOND 1000000 //us
+#define ONE_SECOND 1000000 // us
 
 //==============================================================================
 // Function Prototypes
@@ -41,10 +44,13 @@ static swadgeMode_t* getRandomSwadgeMode(void);
 // Variables
 //==============================================================================
 
-// Quickly regenerate with:
-// grep -hirE '^extern swadgeMode_t (.*);' main/modes/ | awk '{print $3}' | sed -E 's/(.*);/\&\1,/g' | grep -v quickSettings | sort
-static swadgeMode_t* allSwadgeModes[] =
-{
+/*
+ Quickly regenerate with:
+   grep -hirE '^extern swadgeMode_t (.*);' main/modes/ | awk '{print $3}'
+     | sed -E 's/(.*);/\&\1,/g' | grep -v quickSettings | sort
+*/
+// clang-format off
+static swadgeMode_t* allSwadgeModes[] = {
     &accelTestMode,
     &colorchordMode,
     &danceMode,
@@ -55,9 +61,9 @@ static swadgeMode_t* allSwadgeModes[] =
     &touchTestMode,
     &tunernomeMode,
 };
+// clang-format on
 
-emuExtension_t modesEmuExtension =
-{
+emuExtension_t modesEmuExtension = {
     .name            = "modes",
     .fnInitCb        = modesInitCb,
     .fnPreFrameCb    = modesPreFrameCb,
@@ -107,18 +113,18 @@ void modesPreFrameCb(uint64_t frame)
         // Periodic mode switching is enabled!
         // Keep track of when we need to switch modes
         static int64_t lastTime = 0;
-        static int64_t timer = 0;
+        static int64_t timer    = 0;
 
         if (lastTime == 0)
         {
             lastTime = esp_timer_get_time();
-            timer = ((int64_t)emulatorArgs.modeSwitchTime) * ONE_SECOND;
+            timer    = ((int64_t)emulatorArgs.modeSwitchTime) * ONE_SECOND;
         }
         else
         {
-            int64_t now = esp_timer_get_time();
+            int64_t now     = esp_timer_get_time();
             int64_t elapsed = now - lastTime;
-            lastTime = now;
+            lastTime        = now;
             if (elapsed >= timer)
             {
                 timer = ((int64_t)emulatorArgs.modeSwitchTime * ONE_SECOND) - (elapsed - timer);
@@ -129,7 +135,6 @@ void modesPreFrameCb(uint64_t frame)
                 timer -= elapsed;
             }
         }
-
     }
 }
 

--- a/emulator/src/extensions/modes/ext_modes.c
+++ b/emulator/src/extensions/modes/ext_modes.c
@@ -1,0 +1,158 @@
+//==============================================================================
+// Includes
+//==============================================================================
+
+#include "ext_modes.h"
+#include "emu_main.h"
+#include "esp_timer.h"
+#include "esp_sleep_emu.h"
+#include "macros.h"
+
+#include <stdlib.h>
+
+// Mode Includes
+// Quickly regenerate with:
+// grep -lirE '^extern swadgeMode_t (.*);' | grep -oE '([^/]+\.h)' | grep -v quickSettings | awk '{printf "#include \"%s\"\n",$1 }' | sort
+#include "accelTest.h"
+#include "colorchord.h"
+#include "dance.h"
+#include "demoMode.h"
+#include "jukebox.h"
+#include "mainMenu.h"
+#include "pong.h"
+#include "touchTest.h"
+#include "tunernome.h"
+
+//==============================================================================
+// Defines
+//==============================================================================
+
+#define ONE_SECOND 1000000 //us
+
+//==============================================================================
+// Function Prototypes
+//==============================================================================
+
+bool modesInitCb(emuArgs_t* args);
+void modesPreFrameCb(uint64_t frame);
+static swadgeMode_t* getRandomSwadgeMode(void);
+
+//==============================================================================
+// Variables
+//==============================================================================
+
+// Quickly regenerate with:
+// grep -hirE '^extern swadgeMode_t (.*);' main/modes/ | awk '{print $3}' | sed -E 's/(.*);/\&\1,/g' | grep -v quickSettings | sort
+static swadgeMode_t* allSwadgeModes[] =
+{
+    &accelTestMode,
+    &colorchordMode,
+    &danceMode,
+    &demoMode,
+    &jukeboxMode,
+    &mainMenuMode,
+    &pongMode,
+    &touchTestMode,
+    &tunernomeMode,
+};
+
+emuExtension_t modesEmuExtension =
+{
+    .name            = "modes",
+    .fnInitCb        = modesInitCb,
+    .fnPreFrameCb    = modesPreFrameCb,
+    .fnPostFrameCb   = NULL,
+    .fnKeyCb         = NULL,
+    .fnMouseMoveCb   = NULL,
+    .fnMouseButtonCb = NULL,
+    .fnRenderCb      = NULL,
+};
+
+static swadgeMode_t* startMode = NULL;
+
+//==============================================================================
+// Functions
+//==============================================================================
+
+bool modesInitCb(emuArgs_t* args)
+{
+    if (args->lock)
+    {
+        emulatorSetSwadgeModeLocked(true);
+    }
+
+    if (args->startMode)
+    {
+        startMode = emulatorFindSwadgeMode(args->startMode);
+
+        if (!startMode)
+        {
+            printf("ERR: No swadge mode matching '%s' found.\n", args->startMode);
+            emulatorQuit();
+            return false;
+        }
+    }
+
+    return NULL != startMode || args->modeSwitchTime != 0;
+}
+
+void modesPreFrameCb(uint64_t frame)
+{
+    if (frame == 1 && startMode != NULL)
+    {
+        emulatorForceSwitchToSwadgeMode(startMode);
+    }
+    else if (emulatorArgs.modeSwitchTime != 0)
+    {
+        // Periodic mode switching is enabled!
+        // Keep track of when we need to switch modes
+        static int64_t lastTime = 0;
+        static int64_t timer = 0;
+
+        if (lastTime == 0)
+        {
+            lastTime = esp_timer_get_time();
+            timer = ((int64_t)emulatorArgs.modeSwitchTime) * ONE_SECOND;
+        }
+        else
+        {
+            int64_t now = esp_timer_get_time();
+            int64_t elapsed = now - lastTime;
+            lastTime = now;
+            if (elapsed >= timer)
+            {
+                timer = ((int64_t)emulatorArgs.modeSwitchTime * ONE_SECOND) - (elapsed - timer);
+                emulatorForceSwitchToSwadgeMode(getRandomSwadgeMode());
+            }
+            else
+            {
+                timer -= elapsed;
+            }
+        }
+
+    }
+}
+
+swadgeMode_t** emulatorGetSwadgeModes(int* count)
+{
+    *count = ARRAY_SIZE(allSwadgeModes);
+    return allSwadgeModes;
+}
+
+swadgeMode_t* emulatorFindSwadgeMode(const char* name)
+{
+    for (uint8_t i = 0; i < ARRAY_SIZE(allSwadgeModes); i++)
+    {
+        if (!strncmp(allSwadgeModes[i]->modeName, name, strlen(name)))
+        {
+            return allSwadgeModes[i];
+        }
+    }
+
+    return NULL;
+}
+
+swadgeMode_t* getRandomSwadgeMode(void)
+{
+    return allSwadgeModes[rand() % ARRAY_SIZE(allSwadgeModes)];
+}

--- a/emulator/src/extensions/modes/ext_modes.h
+++ b/emulator/src/extensions/modes/ext_modes.h
@@ -1,0 +1,10 @@
+#pragma once
+#include <stdint.h>
+
+#include "swadge2024.h"
+#include "emu_ext.h"
+
+extern emuExtension_t modesEmuExtension;
+
+swadgeMode_t** emulatorGetSwadgeModes(int* count);
+swadgeMode_t* emulatorFindSwadgeMode(const char* name);

--- a/emulator/src/idf/esp_sleep.c
+++ b/emulator/src/idf/esp_sleep.c
@@ -1,8 +1,11 @@
 #include <unistd.h>
 #include "esp_sleep.h"
+#include "esp_sleep_emu.h"
 #include "swadge2024.h"
 
 static uint64_t timeToLightSleep = 0;
+static bool modeLocked = false;
+static bool overrideLock = false;
 
 esp_sleep_wakeup_cause_t esp_sleep_get_wakeup_cause(void)
 {
@@ -23,8 +26,30 @@ esp_err_t esp_light_sleep_start(void)
 
 void esp_deep_sleep_start(void)
 {
-    // On the emulator, this will switch the Swadge mode without rebooting
-    // On an actual Swadge, this function will reboot the system and the new Swadge mode will be used after reboot
-    softSwitchToPendingSwadge();
-    return;
+    if (modeLocked && !overrideLock)
+    {
+        // Un-turn-off the backlight from when the mode switch was attempted
+        enableTFTBacklight();
+    }
+    else
+    {
+        overrideLock = false;
+
+        // On the emulator, this will switch the Swadge mode without rebooting
+        // On an actual Swadge, this function will reboot the system and the new Swadge mode will be used after reboot
+        softSwitchToPendingSwadge();
+        return;
+    }
+}
+
+void emulatorForceSwitchToSwadgeMode(swadgeMode_t* mode)
+{
+    switchToSwadgeMode(mode);
+    overrideLock = true;
+}
+
+void emulatorSetSwadgeModeLocked(bool locked)
+{
+    modeLocked = locked;
+    overrideLock = false;
 }

--- a/emulator/src/idf/esp_sleep.c
+++ b/emulator/src/idf/esp_sleep.c
@@ -42,12 +42,25 @@ void esp_deep_sleep_start(void)
     }
 }
 
+/**
+ * @brief Forcibly switch the emulator into a different swadge mode, even if it is locked.
+ *
+ * @param mode The swadge mode to force-switch into
+ */
 void emulatorForceSwitchToSwadgeMode(swadgeMode_t* mode)
 {
+    // Switch the swadge mode normally
     switchToSwadgeMode(mode);
+
+    // Allow the next mode change to complete
     overrideLock = true;
 }
 
+/**
+ * @brief Set whether the swadge mode may be changed as normally via ::switchToSwadgeMode()
+ *
+ * @param locked Whether or not the swadge mode should be locked
+ */
 void emulatorSetSwadgeModeLocked(bool locked)
 {
     modeLocked = locked;

--- a/emulator/src/idf/esp_sleep.c
+++ b/emulator/src/idf/esp_sleep.c
@@ -4,8 +4,8 @@
 #include "swadge2024.h"
 
 static uint64_t timeToLightSleep = 0;
-static bool modeLocked = false;
-static bool overrideLock = false;
+static bool modeLocked           = false;
+static bool overrideLock         = false;
 
 esp_sleep_wakeup_cause_t esp_sleep_get_wakeup_cause(void)
 {
@@ -63,6 +63,6 @@ void emulatorForceSwitchToSwadgeMode(swadgeMode_t* mode)
  */
 void emulatorSetSwadgeModeLocked(bool locked)
 {
-    modeLocked = locked;
+    modeLocked   = locked;
     overrideLock = false;
 }


### PR DESCRIPTION
### Description

Fuzzing is back! New features and command-line args are:
* Changing start mode: `-m | --mode NAME`
* Switching modes periodically: `--mode-switch [TIME]`
* Listing modes and exiting: `--modes | --modes-list`
* Locking to start mode: `-l | -lock`
* Enable fuzzing everything: `--fuzz`
* Control fuzzing buttons/touch/accelerometer: `--fuzz-(buttons|touch|motion) [y/n]`
* Mix and match: `--fuzz --fuzz-motion=no`

### Test Instructions

Build the emulator.
Try invoking the emulator with these options and confirm its behavior:
* `--help` - Prints a very pretty help text, which also includes all the fuzzing and mode options, then exits.
* `--modes-list` - Prints a list of all the swadge mode names, then exits.
* `--fuzz` - Should print out a message to indicate buttons, touch, and accel are being fuzzed, then the main menu should start and go crazy with lots of inputs immediately. Other modes should still be accessible
* `--lock` - Emulator should start normally. Check that selecting a mode on the main menu does nothing.
* `--mode Demo` - Emulator should start directly into the Demo mode. Holding SELECT should exit the mode.
* `--mode Demo --lock` - Emulator should start directly into the Demo mode. Holding SELECT should draw the exit progress bar, but not exit.
* `--mode asdf` - Emulator should exit immediately with a helpful error message
* `--mode Touch --fuzz-motion`  Emulator should start directly into the Motion Test mode, and only input touch events. You can see that there are no fuzzed button presses happening by trying to exit the mode or enter quick settings.
* `--mode-switch` - Emulator should start in the Main Menu, then every 10 seconds switch into a random mode, but otherwise work normally
* `--mode-switch 1` - Emulator should start in the Main Menu, then every second switch into a random mode, but otherwise work normally.
* `--fuzz --mode-switch --lock --mode Pong` - Emulator should start inside Pong, then immediately begin fuzzing and switching modes every 10 seconds, without otherwise changing modes.

### Ticket Links

<!--- Link any tickets that are completed in this pull request. -->

### Readiness Checklist
- [x] I have run `make format` to format the changes
- [x] I have compiled the firmware and the changes have no warnings
- [x] I have compiled the emulator and the changes have no warnings
- [x] I have run `make cppcheck` and checked that `cppcheck_result.txt` has no warnings for the changes
- [x] I have added doxygen comments to any code used by more than one Swadge mode. This includes `/*! \file` comments with Design Philosophy, Usage, and Example sections for new headers.
- [x] I have run `make docs` and checked that `doxy_warnings.txt` has no warnings for the new code
