### PR TITLE
Record/Playback Emulator Inputs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,5 @@ version.txt
 plantuml.jar
 swadge_emulator
 crash-*.txt
+screenshot-*.bmp
+rec-*.csv

--- a/emulator/src/emu_main.c
+++ b/emulator/src/emu_main.c
@@ -35,8 +35,6 @@
 // Useful if you're trying to find the code for a key/button
 // #define DEBUG_INPUTS
 
-#define EMU_EXTENSIONS
-
 #include "emu_args.h"
 #include "emu_ext.h"
 #include "emu_main.h"
@@ -118,7 +116,6 @@ int main(int argc, char** argv)
         return 0;
     }
 
-#ifdef EMU_EXTENSIONS
     // Call any init callbacks we may have and pass them the parsed command-line arguments
     // We also determine which extensions are enabled here, which is important for laying out the window properly
     initExtensions(&emulatorArgs);
@@ -128,7 +125,6 @@ int main(int argc, char** argv)
         // One of the extension must have quit due to an error.
         return 0;
     }
-#endif
 
     // First initialize rawdraw
     // Screen-specific configurations
@@ -163,11 +159,9 @@ int main(int argc, char** argv)
  */
 void taskYIELD(void)
 {
-#ifdef EMU_EXTENSIONS
     // Count total frames, just for callback reasons
     static uint64_t frameNum = 0;
     doExtPostFrameCb(frameNum);
-#endif
 
     // Calculate time between calls
     static int64_t tLastCallUs = 0;
@@ -280,10 +274,8 @@ void taskYIELD(void)
         CNFGBlitImage(bitmapDisplay, screenPane.paneX, screenPane.paneY, bitmapWidth, bitmapHeight);
     }
 
-#ifdef EMU_EXTENSIONS
     // After the screen has been fully rendered, call all the render callbacks to render anything else
     doExtRenderCb(window_w, window_h);
-#endif
 
     // Display the image and wait for time to display next frame.
     CNFGSwapBuffers();
@@ -296,9 +288,7 @@ void taskYIELD(void)
     };
     nanosleep(&tSleep, &tRemaining);
 
-#ifdef EMU_EXTENSIONS
     doExtPreFrameCb(++frameNum);
-#endif
 
     // Below: Support for pausing and unpausing the emulator
     // Note:  Remove the above doExtPreFrameCb()... if uncommenting the below
@@ -399,13 +389,11 @@ void HandleKey(int keycode, int bDown)
     }
 #endif
 
-#ifdef EMU_EXTENSIONS
     keycode = doExtKeyCb(keycode, bDown);
     if (keycode < 0)
     {
         return;
     }
-#endif
 
     // Assuming no callbacks canceled the key event earlier, handle it normally
     emulatorHandleKeys(keycode, bDown);
@@ -441,9 +429,7 @@ void HandleButton(int x, int y, int button, int bDown)
     printf("HandleButton(x=%d, y=%d, button=%x, bDown=%s\n", x, y, button, bDown ? "true" : "false");
 #endif
 
-#ifdef EMU_EXTENSIONS
     doExtMouseButtonCb(x, y, button, bDown);
-#endif
 }
 
 /**
@@ -459,9 +445,7 @@ void HandleMotion(int x, int y, int mask)
     printf("HandleMotion(x=%d, y=%d, mask=%x\n", x, y, mask);
 #endif
 
-#ifdef EMU_EXTENSIONS
     doExtMouseMoveCb(x, y, mask);
-#endif
 }
 
 /**

--- a/emulator/src/emu_main.c
+++ b/emulator/src/emu_main.c
@@ -140,8 +140,8 @@ int main(int argc, char** argv)
         calculatePaneMinimums(&paneMins);
         int32_t sidePanesW      = paneMins[PANE_LEFT].min + paneMins[PANE_RIGHT].min;
         int32_t topBottomPanesH = paneMins[PANE_TOP].min + paneMins[PANE_BOTTOM].min;
-        int32_t winW            = (TFT_WIDTH) * 2 + sidePanesW;
-        int32_t winH            = (TFT_HEIGHT) * 2 + topBottomPanesH;
+        int32_t winW            = (TFT_WIDTH)*2 + sidePanesW;
+        int32_t winH            = (TFT_HEIGHT)*2 + topBottomPanesH;
 
         if (emulatorArgs.headless)
         {

--- a/emulator/src/emu_main.c
+++ b/emulator/src/emu_main.c
@@ -140,9 +140,19 @@ int main(int argc, char** argv)
         calculatePaneMinimums(&paneMins);
         int32_t sidePanesW      = paneMins[PANE_LEFT].min + paneMins[PANE_RIGHT].min;
         int32_t topBottomPanesH = paneMins[PANE_TOP].min + paneMins[PANE_BOTTOM].min;
+        int32_t winW            = (TFT_WIDTH) * 2 + sidePanesW;
+        int32_t winH            = (TFT_HEIGHT) * 2 + topBottomPanesH;
+
+        if (emulatorArgs.headless)
+        {
+            // If the window dimensions are negative, the window will still exist but not be displayed.
+            // TODO does this work on all platforms?
+            winW = -winW;
+            winH = -winH;
+        }
 
         // Add the screen size to the minimum pane sizes to get our window size
-        CNFGSetup("Swadge 2024 Simulator", (TFT_WIDTH)*2 + sidePanesW, (TFT_HEIGHT)*2 + topBottomPanesH);
+        CNFGSetup("Swadge 2024 Simulator", winW, winH);
     }
 
     // We won't call the pre-frame callback for the very first frame

--- a/emulator/src/emu_main.c
+++ b/emulator/src/emu_main.c
@@ -136,8 +136,8 @@ int main(int argc, char** argv)
     else
     {
         // Get all the pane info to see how much space we need aside from the simulated TFT screen
-        emuPaneMinimum_t paneMins[5] = {0};
-        calculatePaneMinimums(&paneMins);
+        emuPaneMinimum_t paneMins[4] = {0};
+        calculatePaneMinimums(paneMins);
         int32_t sidePanesW      = paneMins[PANE_LEFT].min + paneMins[PANE_RIGHT].min;
         int32_t topBottomPanesH = paneMins[PANE_TOP].min + paneMins[PANE_BOTTOM].min;
         int32_t winW            = (TFT_WIDTH)*2 + sidePanesW;

--- a/emulator/src/extensions/emu_args.c
+++ b/emulator/src/extensions/emu_args.c
@@ -89,6 +89,8 @@ emuArgs_t emulatorArgs = {
     .fuzzTouch   = false,
     .fuzzMotion  = false,
 
+    .headless = false,
+
     .keymap = NULL,
 
     .lock = false,
@@ -114,6 +116,7 @@ static const char argFuzz[]        = "fuzz";
 static const char argFuzzButtons[] = "fuzz-buttons";
 static const char argFuzzTouch[]   = "fuzz-touch";
 static const char argFuzzMotion[]  = "fuzz-motion";
+static const char argHeadless[]    = "headless";
 static const char argHideLeds[]    = "hide-leds";
 static const char argLock[]        = "lock";
 static const char argMode[]        = "mode";
@@ -136,6 +139,7 @@ static const struct option options[] =
     { argFuzzButtons, optional_argument, (int*)&emulatorArgs.fuzzButtons,  true },
     { argFuzzTouch,   optional_argument, (int*)&emulatorArgs.fuzzTouch,    true },
     { argFuzzMotion,  optional_argument, (int*)&emulatorArgs.fuzzMotion,   true },
+    { argHeadless,    no_argument,       (int*)&emulatorArgs.headless,     true },
     { argHideLeds,    no_argument,       (int*)&emulatorArgs.hideLeds,     true },
     { argLock,        no_argument,       (int*)&emulatorArgs.lock,         true },
     { argMode,        required_argument, NULL,                             'm'  },
@@ -160,6 +164,7 @@ static const optDoc_t argDocs[] =
     { 0,  argFuzzButtons, "y|n",   "Set whether buttons are fuzzed" },
     { 0,  argFuzzTouch,   "y|n",   "Set whether touchpad inputs are fuzzed" },
     { 0,  argFuzzMotion,  "y|n",   "Set whether motion inputs are fuzzed" },
+    { 0,  argHeadless,    NULL,    "Runs the emulator without a window." },
     { 0,  argHideLeds,    NULL,    "Don't draw simulated LEDs next to the display" },
     {'l', argLock,        NULL,    "Lock the emulator in the start mode" },
     {'m', argMode,        "MODE",  "Start the emulator in the swadge mode MODE instead of the main menu"},

--- a/emulator/src/extensions/emu_args.c
+++ b/emulator/src/extensions/emu_args.c
@@ -272,7 +272,8 @@ static bool handleArgument(const char* optName, const char* arg, int optVal)
             // Use default
             emulatorArgs.modeSwitchTime = optVal;
         }
-    } else if (argRecord == optName)
+    }
+    else if (argRecord == optName)
     {
         if (emulatorArgs.playback)
         {

--- a/emulator/src/extensions/emu_args.c
+++ b/emulator/src/extensions/emu_args.c
@@ -188,10 +188,7 @@ static const optDoc_t argDocs[] =
  */
 static bool handleArgument(const char* optName, const char* arg, int optVal)
 {
-    // Handle arguments with no short-option like this:
-    // if (optName == argUsage)
-    //{ doSomething(); return true }
-
+    // Handle all arguments by their long-option, as it will always be set.
     if (argFuzz == optName)
     {
         // Enable Fuzz
@@ -270,52 +267,31 @@ static bool handleArgument(const char* optName, const char* arg, int optVal)
             // Use default
             emulatorArgs.modeSwitchTime = optVal;
         }
-    }
-
-    // Handle options with a short-option here:
-    switch (optVal)
+    } else if (argRecord == optName)
     {
-
-        // Handle argPlayback
-        case 'p':
+        if (emulatorArgs.playback)
         {
-            if (emulatorArgs.record)
-            {
-                printf("Cannot playback and record at the same time\n");
-                return false;
-            }
-
-            if (arg)
-            {
-                emulatorArgs.replayFile = arg;
-            }
-            break;
+            printf("ERR: Cannot playback and record at the same time\n");
+            return false;
         }
 
-        // Handle argRecord
-        case 'r':
+        if (arg)
         {
-            if (emulatorArgs.playback)
-            {
-                printf("Cannot playback and record at the same time\n");
-                return false;
-            }
-
-            if (arg)
-            {
-                printf("Got recordFile %s\n", arg);
-                emulatorArgs.recordFile = arg;
-            }
-            break;
+            emulatorArgs.recordFile = arg;
+        }
+    }
+    else if (argPlayback == optName)
+    {
+        if (emulatorArgs.record)
+        {
+            printf("ERR: Cannot playback and record at the same time\n");
+            return false;
         }
 
-            // case 'x':
-            // doSomething();
-            // if (error) return false;
-            // return true;
-
-        default:
-            break;
+        if (arg)
+        {
+            emulatorArgs.replayFile = arg;
+        }
     }
 
     // It's OK if an arg is unhandled, as it may just be a flag set automatically

--- a/emulator/src/extensions/emu_args.c
+++ b/emulator/src/extensions/emu_args.c
@@ -105,7 +105,7 @@ emuArgs_t emulatorArgs = {
 
     .emulateTouch = false,
 
-    .record = false,
+    .record   = false,
     .playback = false,
 
     .recordFile = NULL,

--- a/emulator/src/extensions/emu_args.c
+++ b/emulator/src/extensions/emu_args.c
@@ -119,6 +119,8 @@ static const char argLock[]        = "lock";
 static const char argMode[]        = "mode";
 static const char argModeSwitch[]  = "mode-switch";
 static const char argModeList[]    = "modes-list";
+static const char argPlayback[]    = "playback";
+static const char argRecord[]      = "record";
 static const char argTouch[]       = "touch";
 static const char argHelp[]        = "help";
 static const char argUsage[]       = "usage";
@@ -137,6 +139,8 @@ static const struct option options[] =
     { argHideLeds,    no_argument,       (int*)&emulatorArgs.hideLeds,     true },
     { argLock,        no_argument,       (int*)&emulatorArgs.lock,         true },
     { argMode,        required_argument, NULL,                             'm'  },
+    { argPlayback,    required_argument, (int*)&emulatorArgs.playback,     'p'  },
+    { argRecord,      optional_argument, (int*)&emulatorArgs.record,       'r'  },
     { argModeSwitch,  optional_argument, NULL,                             10   },
     { argModeList,    no_argument,       NULL,                             0    },
     { argTouch,       no_argument,       (int*)&emulatorArgs.emulateTouch, true },
@@ -161,6 +165,8 @@ static const optDoc_t argDocs[] =
     {'m', argMode,        "MODE",  "Start the emulator in the swadge mode MODE instead of the main menu"},
     { 0,  argModeSwitch,  "TIME",  "Enable or set the timer to switch modes automatically" },
     { 0,  argModeList,    NULL,    "Print out a list of all possible values for MODE" },
+    {'p', argPlayback,    "FILE",  "Play back recorded emulator inputs from a file" },
+    {'r', argRecord,      "FILE",  "Record emulator inputs to a file" },
     {'t', argTouch,       NULL,    "Simulate touch sensor readings with a virtual touchpad" },
     {'h', argHelp,        NULL,    "Give this help list" },
     { 0,  argUsage,       NULL,    "Give a short usage message" },
@@ -269,6 +275,40 @@ static bool handleArgument(const char* optName, const char* arg, int optVal)
     // Handle options with a short-option here:
     switch (optVal)
     {
+
+        // Handle argPlayback
+        case 'p':
+        {
+            if (emulatorArgs.record)
+            {
+                printf("Cannot playback and record at the same time\n");
+                return false;
+            }
+
+            if (arg)
+            {
+                emulatorArgs.replayFile = arg;
+            }
+            break;
+        }
+
+        // Handle argRecord
+        case 'r':
+        {
+            if (emulatorArgs.playback)
+            {
+                printf("Cannot playback and record at the same time\n");
+                return false;
+            }
+
+            if (arg)
+            {
+                printf("Got recordFile %s\n", arg);
+                emulatorArgs.recordFile = arg;
+            }
+            break;
+        }
+
             // case 'x':
             // doSomething();
             // if (error) return false;

--- a/emulator/src/extensions/emu_args.c
+++ b/emulator/src/extensions/emu_args.c
@@ -104,6 +104,12 @@ emuArgs_t emulatorArgs = {
     .motionDrift        = false,
 
     .emulateTouch = false,
+
+    .record = false,
+    .playback = false,
+
+    .recordFile = NULL,
+    .replayFile = NULL,
 };
 
 static const char mainDoc[] = "Emulates a swadge";

--- a/emulator/src/extensions/emu_args.h
+++ b/emulator/src/extensions/emu_args.h
@@ -43,6 +43,12 @@ typedef struct
     bool motionDrift;
 
     bool emulateTouch;
+
+    /// @brief Name of the file to record inputs to
+    const char* recordFile;
+
+    /// @brief Name of the file to replay inputs from
+    const char* replayFile;
 } emuArgs_t;
 
 //==============================================================================

--- a/emulator/src/extensions/emu_args.h
+++ b/emulator/src/extensions/emu_args.h
@@ -29,6 +29,8 @@ typedef struct
     bool fuzzTouch;
     bool fuzzMotion;
 
+    bool headless;
+
     /// @brief Name of the keymap to use, or NULL if none
     const char* keymap;
 

--- a/emulator/src/extensions/emu_args.h
+++ b/emulator/src/extensions/emu_args.h
@@ -42,9 +42,19 @@ typedef struct
     uint16_t motionJitterAmount;
     bool motionDrift;
 
+    // Touch Extension
+
     bool emulateTouch;
 
-    /// @brief Name of the file to record inputs to
+    // Replay Extension
+
+    /// @brief Whether or not to record the inputs to a file
+    bool record;
+
+    /// @brief Whether or not to play back recorded inputs from a file
+    bool playback;
+
+    /// @brief Name of the file to record inputs to, or NULL for the default
     const char* recordFile;
 
     /// @brief Name of the file to replay inputs from

--- a/emulator/src/extensions/emu_ext.c
+++ b/emulator/src/extensions/emu_ext.c
@@ -38,7 +38,6 @@ static const emuExtension_t* registeredExtensions[] = {
 #define EMU_CB_LOOP_BARE    for (node_t* node = extManager.extensions.first; node != NULL; node = node->next)
 #define EMU_CB_INFO         ((emuExtInfo_t*)(node->val))
 #define EMU_CB_HAS_FN(cbFn) (EMU_CB_INFO->extension && EMU_CB_INFO->extension->cbFn)
-#define EMU_CB_NAME         (EMU_CB_INFO->extension->name)
 
 /**
  * @brief Macro to be used as a for-loop replacement for calling a particular callback
@@ -112,7 +111,7 @@ static emuExtManager_t extManager = {0};
 //==============================================================================
 
 static emuExtInfo_t* findExtInfo(const emuExtension_t* ext);
-static emuExtension_t* findExt(const char* name);
+static const emuExtension_t* findExt(const char* name);
 
 //==============================================================================
 // Functions
@@ -154,7 +153,7 @@ static emuExtInfo_t* findExtInfo(const emuExtension_t* ext)
  * @param name
  * @return const emuExtension_t*
  */
-static emuExtension_t* findExt(const char* name)
+static const emuExtension_t* findExt(const char* name)
 {
     const emuExtension_t** cbList = registeredExtensions;
 
@@ -202,7 +201,7 @@ static void preloadExtensions(void)
  *
  * @param args
  */
-void initExtensions(const emuArgs_t* args)
+void initExtensions(emuArgs_t* args)
 {
     preloadExtensions();
 
@@ -472,9 +471,8 @@ void layoutPanes(int32_t winW, int32_t winH, int32_t screenW, int32_t screenH, e
     // Only set the pane dimensions if there are actually any panes, to avoid division-by-zero
     if (paneInfos[PANE_LEFT].count > 0)
     {
-        winPanes[PANE_LEFT].paneW
-            = MAX(0, (winW - rightDivW - leftDivW - screenPane->paneW) * (paneInfos[PANE_LEFT].min)
-                         / (paneInfos[PANE_LEFT].min + paneInfos[PANE_RIGHT].min));
+        winPanes[PANE_LEFT].paneW = (winW - rightDivW - leftDivW - screenPane->paneW) * (paneInfos[PANE_LEFT].min)
+                                    / (paneInfos[PANE_LEFT].min + paneInfos[PANE_RIGHT].min);
         winPanes[PANE_LEFT].paneH = winH;
     }
 
@@ -487,7 +485,7 @@ void layoutPanes(int32_t winW, int32_t winH, int32_t screenW, int32_t screenH, e
     if (paneInfos[PANE_RIGHT].count > 0)
     {
         winPanes[PANE_RIGHT].paneW
-            = MAX(0, winW - (winPanes[PANE_LEFT].paneW + leftDivW + screenPane->paneW + rightDivW));
+            = winW - (winPanes[PANE_LEFT].paneW + leftDivW + screenPane->paneW + rightDivW);
         winPanes[PANE_RIGHT].paneH = winH;
     }
 
@@ -498,8 +496,8 @@ void layoutPanes(int32_t winW, int32_t winH, int32_t screenW, int32_t screenH, e
     {
         winPanes[PANE_TOP].paneW = screenPane->paneW;
         // Assign the remaining space to the left and right panes proportionally with their minimum sizes
-        winPanes[PANE_TOP].paneH = MAX(0, (winH - bottomDivH - topDivH - screenPane->paneH) * (paneInfos[PANE_TOP].min)
-                                              / (paneInfos[PANE_TOP].min + paneInfos[PANE_BOTTOM].min));
+        winPanes[PANE_TOP].paneH = (winH - bottomDivH - topDivH - screenPane->paneH) * (paneInfos[PANE_TOP].min)
+                                              / (paneInfos[PANE_TOP].min + paneInfos[PANE_BOTTOM].min);
     }
 
     // For the bottom one, flip things around just a bit so we can center the screen properly
@@ -508,7 +506,7 @@ void layoutPanes(int32_t winW, int32_t winH, int32_t screenW, int32_t screenH, e
         winPanes[PANE_BOTTOM].paneW = screenPane->paneW;
         // Assign whatever space is left to the right pane to account for roundoff
         winPanes[PANE_BOTTOM].paneH
-            = MAX(0, winH - (winPanes[PANE_TOP].paneH + topDivH + screenPane->paneH + bottomDivH));
+            = winH - (winPanes[PANE_TOP].paneH + topDivH + screenPane->paneH + bottomDivH);
     }
 
     // The screen will be just below the top pane and its divider, plus half of any extra space not used by the panes

--- a/emulator/src/extensions/emu_ext.c
+++ b/emulator/src/extensions/emu_ext.c
@@ -17,6 +17,7 @@
 #include "ext_leds.h"
 #include "ext_fuzzer.h"
 #include "ext_modes.h"
+#include "ext_replay.h"
 
 //==============================================================================
 // Registered Extensions
@@ -31,6 +32,7 @@ static const emuExtension_t* registeredExtensions[] = {
     &ledEmuExtension,
     &fuzzerEmuExtension,
     &modesEmuExtension,
+    &replayEmuExtension,
 };
 
 //==============================================================================

--- a/emulator/src/extensions/emu_ext.c
+++ b/emulator/src/extensions/emu_ext.c
@@ -266,9 +266,7 @@ bool enableExtension(const char* name)
     emuExtInfo_t* extInfo = findExtInfo(findExt(name));
     if (NULL != extInfo)
     {
-        extInfo->enabled = true;
-
-        if (!extInfo->initialized)
+        if (!extInfo->initialized || !extInfo->enabled)
         {
             if (extInfo->extension->fnInitCb)
             {
@@ -284,6 +282,8 @@ bool enableExtension(const char* name)
         {
             extManager.paneMinsCalculated = false;
         }
+
+        extInfo->enabled = true;
 
         return true;
     }

--- a/emulator/src/extensions/emu_ext.c
+++ b/emulator/src/extensions/emu_ext.c
@@ -28,11 +28,7 @@
 //==============================================================================
 
 static const emuExtension_t* registeredExtensions[] = {
-    &touchEmuCallback,
-    &ledEmuExtension,
-    &fuzzerEmuExtension,
-    &modesEmuExtension,
-    &replayEmuExtension,
+    &touchEmuCallback, &ledEmuExtension, &fuzzerEmuExtension, &modesEmuExtension, &replayEmuExtension,
 };
 
 //==============================================================================

--- a/emulator/src/extensions/emu_ext.h
+++ b/emulator/src/extensions/emu_ext.h
@@ -243,7 +243,7 @@ typedef struct
 // Function Prototypes
 //==============================================================================
 
-void initExtensions(const emuArgs_t* args);
+void initExtensions(emuArgs_t* args);
 void deinitExtensions(void);
 bool enableExtension(const char* name);
 bool disableExtension(const char* name);

--- a/emulator/src/extensions/modes/ext_modes.c
+++ b/emulator/src/extensions/modes/ext_modes.c
@@ -161,3 +161,18 @@ swadgeMode_t* getRandomSwadgeMode(void)
 {
     return allSwadgeModes[rand() % ARRAY_SIZE(allSwadgeModes)];
 }
+
+bool emulatorSetSwadgeModeByName(const char* name)
+{
+    swadgeMode_t* mode = emulatorFindSwadgeMode(name);
+
+    if (NULL != mode)
+    {
+        emulatorForceSwitchToSwadgeMode(mode);
+        return true;
+    }
+    else
+    {
+        return false;
+    }
+}

--- a/emulator/src/extensions/modes/ext_modes.h
+++ b/emulator/src/extensions/modes/ext_modes.h
@@ -8,3 +8,4 @@ extern emuExtension_t modesEmuExtension;
 
 swadgeMode_t** emulatorGetSwadgeModes(int* count);
 swadgeMode_t* emulatorFindSwadgeMode(const char* name);
+bool emulatorSetSwadgeModeByName(const char* name);

--- a/emulator/src/extensions/replay/ext_replay.c
+++ b/emulator/src/extensions/replay/ext_replay.c
@@ -1,7 +1,6 @@
 #include "ext_replay.h"
 #include "emu_ext.h"
 #include "esp_timer.h"
-#include "esp_timer_emu.h"
 #include "hdw-btn.h"
 #include "hdw-btn_emu.h"
 #include "hdw-accel.h"
@@ -12,6 +11,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <inttypes.h>
+#include <time.h>
 
 #ifdef DEBUG
 #define REPLAY_DEBUG(str, ...) printf(str "\n", __VA_ARGS__);
@@ -144,19 +144,21 @@ replay_t replay;
 
 static bool replayInit(emuArgs_t* emuArgs)
 {
-    //emuArgs->replayFile =
-    emuArgs->replayFile = "rec1.csv";
-
     memset(&replay, 0, sizeof(replay_t));
 
-    if (emuArgs->recordFile)
+    if (emuArgs->record)
     {
-        replay.file = fopen(emuArgs->recordFile, "a");
+        struct timespec ts;
+        char filename[64];
+        clock_gettime(CLOCK_REALTIME, &ts);
+        snprintf(filename, sizeof(filename) - 1, "rec-%lu.csv", ts.tv_sec);
+
+        replay.file = fopen(emuArgs->recordFile ? emuArgs->recordFile : filename, "a");
         replay.mode = RECORD;
         replay.useFrames = false;
         return replay.file != NULL;
     }
-    else if (emuArgs->replayFile)
+    else if (emuArgs->playback)
     {
         replay.file = fopen(emuArgs->replayFile, "r");
         replay.mode = REPLAY;

--- a/emulator/src/extensions/replay/ext_replay.c
+++ b/emulator/src/extensions/replay/ext_replay.c
@@ -23,9 +23,9 @@
 #define HEADER "Time,Type,Value\n"
 
 #ifdef DEBUG
-#define REPLAY_DEBUG(str, ...) printf(str "\n", __VA_ARGS__);
+    #define REPLAY_DEBUG(str, ...) printf(str "\n", __VA_ARGS__);
 #else
-#define REPLAY_DEBUG(str, ...)
+    #define REPLAY_DEBUG(str, ...)
 #endif
 
 //==============================================================================
@@ -65,7 +65,8 @@ typedef struct
 
     replayLogType_t type;
 
-    union {
+    union
+    {
         buttonBit_t buttonVal;
         int32_t touchVal;
         int16_t accelVal;
@@ -111,35 +112,15 @@ static void writeLe(uint8_t* vals, uint32_t size, FILE* stream);
 // Variables
 //==============================================================================
 
-static const char* replayLogTypeStrs[] =
-{
-    "BtnDown",
-    "BtnUp",
-    "TouchPhi",
-    "TouchR",
-    "TouchI",
-    "AccelX",
-    "AccelY",
-    "AccelZ",
-    "Fuzz",
-    "Quit",
-    "Screenshot",
+static const char* replayLogTypeStrs[] = {
+    "BtnDown", "BtnUp", "TouchPhi", "TouchR", "TouchI", "AccelX", "AccelY", "AccelZ", "Fuzz", "Quit", "Screenshot",
 };
 
-static const char* replayButtonNames[] =
-{
-    "Up",
-    "Down",
-    "Left",
-    "Right",
-    "A",
-    "B",
-    "Start",
-    "Select",
+static const char* replayButtonNames[] = {
+    "Up", "Down", "Left", "Right", "A", "B", "Start", "Select",
 };
 
-emuExtension_t replayEmuExtension =
-{
+emuExtension_t replayEmuExtension = {
     .name            = "replay",
     .fnInitCb        = replayInit,
     .fnPreFrameCb    = replayPreFrame,
@@ -207,8 +188,8 @@ static void replayRecordFrame(uint64_t frame)
     int32_t touchPhi, touchR, touchIntensity;
     if (!getTouchJoystick(&touchPhi, &touchR, &touchIntensity))
     {
-        touchPhi = 0;
-        touchR = 0;
+        touchPhi       = 0;
+        touchR         = 0;
         touchIntensity = 0;
     }
 
@@ -216,7 +197,6 @@ static void replayRecordFrame(uint64_t frame)
     accelGetAccelVec(&accelX, &accelY, &accelZ);
 
     buttonBit_t curButtons = emulatorGetButtonState();
-
 
     for (replayLogType_t type = BUTTON_PRESS; type <= LAST_TYPE; type += 1)
     {
@@ -231,8 +211,8 @@ static void replayRecordFrame(uint64_t frame)
                     buttonBit_t btn = (1 << i);
                     if ((curButtons & btn) != (replay.lastButtons & btn))
                     {
-                        bool press = (curButtons & btn) == btn;
-                        logEntry.type = press ? BUTTON_PRESS : BUTTON_RELEASE;
+                        bool press         = (curButtons & btn) == btn;
+                        logEntry.type      = press ? BUTTON_PRESS : BUTTON_RELEASE;
                         logEntry.buttonVal = btn;
                         writeEntry(&logEntry);
 
@@ -250,8 +230,8 @@ static void replayRecordFrame(uint64_t frame)
             }
 
             case BUTTON_RELEASE:
-            // Handled already by BUTTON_PRESS for fastness
-            break;
+                // Handled already by BUTTON_PRESS for fastness
+                break;
 
             case TOUCH_PHI:
             {
@@ -317,16 +297,16 @@ static void replayRecordFrame(uint64_t frame)
             case FUZZ:
             case QUIT:
             case SCREENSHOT:
-            break;
+                break;
         }
     }
 
-    replay.lastTouchR = touchR;
-    replay.lastTouchPhi = touchPhi;
+    replay.lastTouchR         = touchR;
+    replay.lastTouchPhi       = touchPhi;
     replay.lastTouchIntensity = touchIntensity;
-    replay.lastAccelX = accelX;
-    replay.lastAccelY = accelY;
-    replay.lastAccelZ = accelZ;
+    replay.lastAccelX         = accelX;
+    replay.lastAccelY         = accelY;
+    replay.lastAccelZ         = accelZ;
 
     // Flush all the entries to the file so that we can close the file the proper way
     // which is obviously to let the OS deal with it when the process exits
@@ -343,9 +323,9 @@ static void replayPlaybackFrame(uint64_t frame)
     // Unless we've finished reading the file completely
     if (!replay.readCompleted)
     {
-        int64_t time = esp_timer_get_time();
-        int32_t touchPhi = replay.lastTouchPhi;
-        int32_t touchR = replay.lastTouchR;
+        int64_t time           = esp_timer_get_time();
+        int32_t touchPhi       = replay.lastTouchPhi;
+        int32_t touchR         = replay.lastTouchR;
         int32_t touchIntensity = replay.lastTouchIntensity;
 
         int16_t accelX = replay.lastAccelX;
@@ -410,10 +390,10 @@ static void replayPlaybackFrame(uint64_t frame)
 
                 case FUZZ:
                 {
-                    emulatorArgs.fuzz = true;
+                    emulatorArgs.fuzz        = true;
                     emulatorArgs.fuzzButtons = true;
-                    emulatorArgs.fuzzTouch = true;
-                    emulatorArgs.fuzzMotion = true;
+                    emulatorArgs.fuzzTouch   = true;
+                    emulatorArgs.fuzzMotion  = true;
 
                     printf("Replay: Enabling Fuzzer");
                     enableExtension("fuzzer");
@@ -463,12 +443,13 @@ static void replayPlaybackFrame(uint64_t frame)
             }
         }
 
-        if (touchPhi != replay.lastTouchPhi || touchR != replay.lastTouchR || touchIntensity != replay.lastTouchIntensity)
+        if (touchPhi != replay.lastTouchPhi || touchR != replay.lastTouchR
+            || touchIntensity != replay.lastTouchIntensity)
         {
             REPLAY_DEBUG("Updating touch to Phi=%d, R=%d, Intensity=%d\n", touchPhi, touchR, touchIntensity);
             emulatorSetTouchJoystick(touchPhi, touchR, touchIntensity);
-            replay.lastTouchPhi = touchPhi;
-            replay.lastTouchR = touchR;
+            replay.lastTouchPhi       = touchPhi;
+            replay.lastTouchR         = touchR;
             replay.lastTouchIntensity = touchIntensity;
         }
 
@@ -506,8 +487,7 @@ static bool readEntry(replayEntry_t* entry)
     char buffer[64];
     if (!replay.headerHandled)
     {
-        if (1 != fscanf(replay.file, "%63[^\n]\n", buffer)
-           || strncmp(buffer, HEADER, strlen(buffer)))
+        if (1 != fscanf(replay.file, "%63[^\n]\n", buffer) || strncmp(buffer, HEADER, strlen(buffer)))
         {
             // Couldn't read, anything.
             printf("ERR: Invalid playback file, could not parse header\n");
@@ -519,7 +499,7 @@ static bool readEntry(replayEntry_t* entry)
 
     int result;
     // Read timestamp index
-    result = fscanf(replay.file, "%"PRId64",", &replay.nextEntry.time);
+    result = fscanf(replay.file, "%" PRId64 ",", &replay.nextEntry.time);
 
     // Check if the index key was readable
     if (result != 1)
@@ -581,7 +561,7 @@ static bool readEntry(replayEntry_t* entry)
 
                 if (i == 7)
                 {
-                // Should have broken by now, throw error
+                    // Should have broken by now, throw error
                     printf("ERR: Can't find button matching '%s'\n", buffer);
                     return false;
                 }
@@ -594,7 +574,7 @@ static bool readEntry(replayEntry_t* entry)
         case TOUCH_R:
         case TOUCH_INTENSITY:
         {
-            if (1 != fscanf(replay.file, "%"PRId32"\n", &replay.nextEntry.touchVal))
+            if (1 != fscanf(replay.file, "%" PRId32 "\n", &replay.nextEntry.touchVal))
             {
                 return false;
             }
@@ -623,7 +603,8 @@ static bool readEntry(replayEntry_t* entry)
         case QUIT:
         {
             // Just advance to the next line
-            while (fgetc(replay.file) != '\n');
+            while (fgetc(replay.file) != '\n')
+                ;
             break;
         }
 
@@ -633,7 +614,8 @@ static bool readEntry(replayEntry_t* entry)
             if (1 != fscanf(replay.file, "%63[^\n]\n", buffer))
             {
                 // Skip to the end
-                while (fgetc(replay.file) != '\n');
+                while (fgetc(replay.file) != '\n')
+                    ;
                 entry->filename = NULL;
             }
             else
@@ -662,7 +644,7 @@ static void writeEntry(const replayEntry_t* entry)
 #define BUFSIZE (buffer + sizeof(buffer) - 1 - ptr)
 
     // Write time key
-    ptr += snprintf(ptr, BUFSIZE, "%"PRId64",", entry->time);
+    ptr += snprintf(ptr, BUFSIZE, "%" PRId64 ",", entry->time);
 
     // Write entry type
     ptr += snprintf(ptr, BUFSIZE, "%s,", replayLogTypeStrs[entry->type]);
@@ -674,7 +656,8 @@ static void writeEntry(const replayEntry_t* entry)
         {
             // Find button index
             int i = 0;
-            while ((1 << i) != entry->buttonVal && i < 7) {
+            while ((1 << i) != entry->buttonVal && i < 7)
+            {
                 i++;
             }
 
@@ -687,7 +670,7 @@ static void writeEntry(const replayEntry_t* entry)
         case TOUCH_R:
         case TOUCH_INTENSITY:
         {
-            snprintf(ptr, BUFSIZE, "%"PRId32"\n", entry->touchVal);
+            snprintf(ptr, BUFSIZE, "%" PRId32 "\n", entry->touchVal);
             break;
         }
 
@@ -695,7 +678,7 @@ static void writeEntry(const replayEntry_t* entry)
         case ACCEL_Y:
         case ACCEL_Z:
         {
-            snprintf(ptr, BUFSIZE, "%"PRId16"\n", entry->accelVal);
+            snprintf(ptr, BUFSIZE, "%" PRId16 "\n", entry->accelVal);
             break;
         }
 
@@ -743,18 +726,28 @@ bool takeScreenshot(const char* name)
     }
 
 #define BMP_HEADER_SIZE 54
-#define BITS_PER_PIXEL 24
+#define BITS_PER_PIXEL  24
     // Calculate row size accounting for padding
-    uint16_t rowSize = (width * BITS_PER_PIXEL + 31) / 32 * 4;
+    uint16_t rowSize            = (width * BITS_PER_PIXEL + 31) / 32 * 4;
     uint16_t paddingBytesPerRow = ((width * BITS_PER_PIXEL % 32) + 7) / 8;
-    uint32_t pxDataSize = rowSize * height;
-    uint32_t totalSize = pxDataSize + BMP_HEADER_SIZE;
+    uint32_t pxDataSize         = rowSize * height;
+    uint32_t totalSize          = pxDataSize + BMP_HEADER_SIZE;
 
     uint32_t tmp32;
     uint16_t tmp16;
 
-#define WRITE_32(x) do { tmp32 = (x); writeLe((uint8_t*)&tmp32, 4, bmp); } while(0)
-#define WRITE_16(x) do { tmp16 = (x); writeLe((uint8_t*)&tmp16, 2, bmp); } while(0)
+#define WRITE_32(x)                        \
+    do                                     \
+    {                                      \
+        tmp32 = (x);                       \
+        writeLe((uint8_t*)&tmp32, 4, bmp); \
+    } while (0)
+#define WRITE_16(x)                        \
+    do                                     \
+    {                                      \
+        tmp16 = (x);                       \
+        writeLe((uint8_t*)&tmp16, 2, bmp); \
+    } while (0)
 
     // Write bitmap header
     fputc('B', bmp);

--- a/emulator/src/extensions/replay/ext_replay.c
+++ b/emulator/src/extensions/replay/ext_replay.c
@@ -156,7 +156,8 @@ static bool replayInit(emuArgs_t* emuArgs)
         struct timespec ts;
         char filename[64];
         clock_gettime(CLOCK_REALTIME, &ts);
-        snprintf(filename, sizeof(filename) - 1, "rec-%lu.csv", ts.tv_sec);
+        uint64_t timeSec = (uint64_t)ts.tv_sec;
+        snprintf(filename, sizeof(filename) - 1, "rec-%" PRIu64 ".csv", timeSec);
 
         // If specified, use custom filename, otherwise use timestamp one
         printf("\nReplay: Recording inputs to file %s\n", emuArgs->recordFile ? emuArgs->recordFile : filename);
@@ -430,7 +431,10 @@ static void replayPlaybackFrame(uint64_t frame)
                         struct timespec ts;
                         char filename[64];
                         clock_gettime(CLOCK_REALTIME, &ts);
-                        snprintf(filename, sizeof(filename) - 1, "screenshot-%lu.bmp", ts.tv_sec);
+
+                        // Turns out time_t doesn't printf well, so stick it in something that does
+                        uint64_t timeSec = (uint64_t)ts.tv_sec;
+                        snprintf(filename, sizeof(filename) - 1, "screenshot-%" PRIu64 ".bmp", timeSec);
 
                         printf("Replay: Saving screenshot to '%s'\n", filename);
                         takeScreenshot(filename);

--- a/emulator/src/extensions/replay/ext_replay.c
+++ b/emulator/src/extensions/replay/ext_replay.c
@@ -665,7 +665,10 @@ static bool readEntry(replayEntry_t* entry)
                 return false;
             }
 
-            entry->modeName = strndup(buffer, sizeof(buffer) - 1);
+            char* tmpStr = malloc(strlen(buffer) + 1);
+            strncpy(tmpStr, buffer, strlen(buffer) + 1);
+            entry->modeName = tmpStr;
+
             break;
         }
 

--- a/emulator/src/extensions/replay/ext_replay.c
+++ b/emulator/src/extensions/replay/ext_replay.c
@@ -1,0 +1,619 @@
+#include "ext_replay.h"
+#include "emu_ext.h"
+#include "esp_timer.h"
+#include "esp_timer_emu.h"
+#include "hdw-btn.h"
+#include "hdw-btn_emu.h"
+#include "hdw-accel.h"
+#include "hdw-accel_emu.h"
+#include "macros.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <inttypes.h>
+
+#ifdef DEBUG
+#define REPLAY_DEBUG(str, ...) printf(str "\n", __VA_ARGS__);
+#else
+#define REPLAY_DEBUG(str, ...)
+#endif
+
+//==============================================================================
+// Enums
+//==============================================================================
+
+typedef enum
+{
+    RECORD,
+    REPLAY,
+} replayMode_t;
+
+typedef enum
+{
+    BUTTON_PRESS,
+    BUTTON_RELEASE,
+    TOUCH_PHI,
+    TOUCH_R,
+    TOUCH_INTENSITY,
+    ACCEL_X,
+    ACCEL_Y,
+    ACCEL_Z,
+} replayLogType_t;
+
+//==============================================================================
+// Structs
+//==============================================================================
+
+typedef struct
+{
+    union {
+        int64_t time;
+        uint64_t frame;
+    };
+
+    replayLogType_t type;
+
+    union {
+        buttonBit_t buttonVal;
+        int32_t touchVal;
+        int16_t accelVal;
+    };
+} replayEntry_t;
+
+typedef struct
+{
+    FILE* file;
+    bool readCompleted;
+
+    replayMode_t mode;
+    bool useFrames;
+    bool headerHandled;
+
+    buttonBit_t lastButtons;
+
+    int32_t lastTouchPhi;
+    int32_t lastTouchR;
+    int32_t lastTouchIntensity;
+
+    int16_t lastAccelX;
+    int16_t lastAccelY;
+    int16_t lastAccelZ;
+
+    replayEntry_t nextEntry;
+} replay_t;
+
+//==============================================================================
+// Function Prototypes
+//==============================================================================
+
+static bool replayInit(emuArgs_t* emuArgs);
+static void replayRecordFrame(uint64_t frame);
+static void replayPlaybackFrame(uint64_t frame);
+static void replayPreFrame(uint64_t frame);
+static void replayPostFrame(uint64_t frame);
+
+static bool readEntry(replayEntry_t* out);
+static void writeEntry(const replayEntry_t* entry);
+
+//==============================================================================
+// Variables
+//==============================================================================
+
+static const char* replayLogTypeStrs[] =
+{
+    "BtnDown",
+    "BtnUp",
+    "TouchPhi",
+    "TouchR",
+    "TouchI",
+    "AccelX",
+    "AccelY",
+    "AccelZ",
+};
+
+static const char* replayButtonNames[] =
+{
+    "Up",
+    "Down",
+    "Left",
+    "Right",
+    "A",
+    "B",
+    "Start",
+    "Select",
+};
+
+emuExtension_t replayEmuExtension =
+{
+    .name            = "replay",
+    .fnInitCb        = replayInit,
+    .fnPreFrameCb    = replayPreFrame,
+    .fnPostFrameCb   = replayPostFrame,
+    .fnKeyCb         = NULL,
+    .fnMouseMoveCb   = NULL,
+    .fnMouseButtonCb = NULL,
+    .fnRenderCb      = NULL,
+};
+
+replay_t replay;
+
+//==============================================================================
+// Functions
+//==============================================================================
+
+static bool replayInit(emuArgs_t* emuArgs)
+{
+    //emuArgs->replayFile =
+    emuArgs->replayFile = "rec1.csv";
+
+    memset(&replay, 0, sizeof(replay_t));
+
+    if (emuArgs->recordFile)
+    {
+        replay.file = fopen(emuArgs->recordFile, "a");
+        replay.mode = RECORD;
+        replay.useFrames = false;
+        return replay.file != NULL;
+    }
+    else if (emuArgs->replayFile)
+    {
+        replay.file = fopen(emuArgs->replayFile, "r");
+        replay.mode = REPLAY;
+
+        // Return true if the file was opened OK and has a valid header and first entry
+        return NULL != replay.file && readEntry(&replay.nextEntry);
+    }
+
+    return false;
+}
+
+static void replayRecordFrame(uint64_t frame)
+{
+    char buffer[64];
+    replayEntry_t logEntry = {0};
+
+    if (!replay.headerHandled)
+    {
+        replay.headerHandled = true;
+        snprintf(buffer, sizeof(buffer) - 1, "%s,Type,Value\n", replay.useFrames ? "Frame" : "Time");
+        fwrite(buffer, 1, strlen(buffer), replay.file);
+    }
+
+    if (replay.useFrames)
+    {
+        logEntry.frame = frame;
+    }
+    else
+    {
+        logEntry.time = esp_timer_get_time();
+    }
+
+    int32_t touchPhi, touchR, touchIntensity;
+    if (!getTouchJoystick(&touchPhi, &touchR, &touchIntensity))
+    {
+        touchPhi = 0;
+        touchR = 0;
+        touchIntensity = 0;
+    }
+
+    int16_t accelX, accelY, accelZ;
+    accelGetAccelVec(&accelX, &accelY, &accelZ);
+
+    buttonBit_t curButtons = emulatorGetButtonState();
+
+
+    for (replayLogType_t type = BUTTON_PRESS; type <= ACCEL_Z; type += 1)
+    {
+        logEntry.type = type;
+
+        switch (type)
+        {
+            case BUTTON_PRESS:
+            {
+                for (uint8_t i = 0; i < 8; i++)
+                {
+                    buttonBit_t btn = (1 << i);
+                    if ((curButtons & btn) != (replay.lastButtons & btn))
+                    {
+                        bool press = (curButtons & btn) == btn;
+                        logEntry.type = press ? BUTTON_PRESS : BUTTON_RELEASE;
+                        logEntry.buttonVal = btn;
+                        writeEntry(&logEntry);
+
+                        if (press)
+                        {
+                            replay.lastButtons |= btn;
+                        }
+                        else
+                        {
+                            replay.lastButtons &= ~btn;
+                        }
+                    }
+                }
+                break;
+            }
+
+            case BUTTON_RELEASE:
+            // Handled already by BUTTON_PRESS for fastness
+            break;
+
+            case TOUCH_PHI:
+                if (touchPhi != replay.lastTouchPhi)
+                {
+                    logEntry.accelVal = touchPhi;
+                    writeEntry(&logEntry);
+                }
+            break;
+
+            case TOUCH_R:
+            if (touchR != replay.lastTouchR)
+            {
+                logEntry.touchVal = touchR;
+                writeEntry(&logEntry);
+            }
+            break;
+
+            case TOUCH_INTENSITY:
+            if (touchIntensity != replay.lastTouchIntensity)
+            {
+                logEntry.touchVal = touchIntensity;
+                writeEntry(&logEntry);
+            }
+            break;
+
+            case ACCEL_X:
+            if (accelX != replay.lastAccelX)
+            {
+                logEntry.accelVal = accelX;
+                writeEntry(&logEntry);
+                break;
+            }
+
+            case ACCEL_Y:
+            if (accelY != replay.lastAccelY)
+            {
+                logEntry.accelVal = accelY;
+                writeEntry(&logEntry);
+                break;
+            }
+
+            case ACCEL_Z:
+            if (accelZ != replay.lastAccelZ)
+            {
+                logEntry.accelVal = accelZ;
+                writeEntry(&logEntry);
+                break;
+            }
+        }
+    }
+
+
+    replay.lastTouchR = touchR;
+    replay.lastTouchPhi = touchPhi;
+    replay.lastTouchIntensity = touchIntensity;
+    replay.lastAccelX = accelX;
+    replay.lastAccelY = accelY;
+    replay.lastAccelZ = accelZ;
+
+    // Flush all the entries to the file so that we can close the file the proper way
+    // which is obviously to let the OS deal with it when the process exits
+    fflush(replay.file);
+}
+
+/**
+ * @brief Play back any recorded actions queued for the given frame
+ *
+ * @param frame
+ */
+static void replayPlaybackFrame(uint64_t frame)
+{
+    // Unless we've finished reading the file completely
+    if (!replay.readCompleted)
+    {
+        int64_t time = esp_timer_get_time();
+        int32_t touchPhi = replay.lastTouchPhi;
+        int32_t touchR = replay.lastTouchR;
+        int32_t touchIntensity = replay.lastTouchIntensity;
+
+        int16_t accelX = replay.lastAccelX;
+        int16_t accelY = replay.lastAccelY;
+        int16_t accelZ = replay.lastAccelZ;
+
+        while (replay.useFrames ? (frame >= replay.nextEntry.frame) : (time >= replay.nextEntry.time))
+        {
+            switch (replay.nextEntry.type)
+            {
+                case BUTTON_PRESS:
+                {
+                    replay.lastButtons |= replay.nextEntry.buttonVal;
+                    REPLAY_DEBUG("Injecting button %x down\n", replay.nextEntry.buttonVal);
+                    emulatorInjectButton(replay.nextEntry.buttonVal, true);
+                    break;
+                }
+
+                case BUTTON_RELEASE:
+                {
+                    replay.lastButtons &= (~replay.nextEntry.buttonVal);
+                    REPLAY_DEBUG("Injecting button %x up\n", replay.nextEntry.buttonVal);
+                    emulatorInjectButton(replay.nextEntry.buttonVal, false);
+                    break;
+                }
+
+                case TOUCH_PHI:
+                {
+                    touchPhi = replay.nextEntry.touchVal;
+                    break;
+                }
+
+                case TOUCH_R:
+                {
+                    touchR = replay.nextEntry.touchVal;
+                    break;
+                }
+
+                case TOUCH_INTENSITY:
+                {
+                    touchIntensity = replay.nextEntry.touchVal;
+                    break;
+                }
+
+                case ACCEL_X:
+                {
+                    accelX = replay.nextEntry.accelVal;
+                    break;
+                }
+
+                case ACCEL_Y:
+                {
+                    accelY = replay.nextEntry.accelVal;
+                    break;
+                }
+
+                case ACCEL_Z:
+                {
+                    accelZ = replay.nextEntry.accelVal;
+                    break;
+                }
+            }
+
+            // Get the next entry
+            if (!readEntry(&replay.nextEntry))
+            {
+                printf("Replay: Reached end of script\n");
+                replay.readCompleted = true;
+                break;
+            }
+        }
+
+        if (touchPhi != replay.lastTouchPhi || touchR != replay.lastTouchR || touchIntensity != replay.lastTouchIntensity)
+        {
+            REPLAY_DEBUG("Updating touch to Phi=%d, R=%d, Intensity=%d\n", touchPhi, touchR, touchIntensity);
+            emulatorSetTouchJoystick(touchPhi, touchR, touchIntensity);
+            replay.lastTouchPhi = touchPhi;
+            replay.lastTouchR = touchR;
+            replay.lastTouchIntensity = touchIntensity;
+        }
+
+        if (accelX != replay.lastAccelX || accelY != replay.lastAccelY || accelZ != replay.lastAccelZ)
+        {
+            REPLAY_DEBUG("Updating accel to X=%d, Y=%d, Z=%d\n", accelX, accelY, accelZ);
+            emulatorSetAccelerometer(accelX, accelY, accelZ);
+            replay.lastAccelX = accelX;
+            replay.lastAccelY = accelY;
+            replay.lastAccelZ = accelZ;
+        }
+    }
+}
+
+static void replayPreFrame(uint64_t frame)
+{
+    switch (replay.mode)
+    {
+        case RECORD:
+        {
+            replayRecordFrame(frame);
+            break;
+        }
+
+        case REPLAY:
+        {
+            replayPlaybackFrame(frame);
+            break;
+        }
+    }
+}
+
+static void replayPostFrame(uint64_t frame)
+{
+    //emuSetEspTimerTime()
+}
+
+static bool readEntry(replayEntry_t* entry)
+{
+    char buffer[64];
+    if (!replay.headerHandled)
+    {
+        if (fscanf(replay.file, "%63[^,],Type,Value\n", buffer))
+        {
+            if (!strncmp(buffer, "Frame", sizeof(buffer) - 1))
+            {
+                // If the header has "Frame" as the first element, go by frame number
+                // Otherwise, we use timestamp
+                replay.useFrames = true;
+            }
+        }
+        else
+        {
+            // Return false, indicating we couldn't read a header.
+            return false;
+        }
+
+        replay.headerHandled = true;
+    }
+
+    int result;
+    // Read index key (frame or timestamp)
+    if (replay.useFrames)
+    {
+        result = fscanf(replay.file, "%"PRIu64",", &replay.nextEntry.frame);
+    }
+    else
+    {
+        result = fscanf(replay.file, "%"PRId64",", &replay.nextEntry.time);
+    }
+
+    // Check if the index key was readable
+    if (result != 1)
+    {
+        if (EOF == result)
+        {
+            // EOF returned; return false without printing an error
+            return false;
+        }
+        else
+        {
+            printf("ERR: Can't read %s from recording: %d\n", replay.useFrames ? "Frame" : "Time", result);
+        }
+        return false;
+    }
+
+    if (1 != fscanf(replay.file, "%63[^,],", buffer))
+    {
+        printf("ERR: Can't read action type\n");
+        return false;
+    }
+
+    for (replayLogType_t type = BUTTON_PRESS; type <= ACCEL_Z; type += 1)
+    {
+        const char* str = replayLogTypeStrs[type];
+        if (!strncmp(str, buffer, sizeof(buffer) - 1))
+        {
+            replay.nextEntry.type = type;
+            break;
+        }
+
+        if (type == ACCEL_Z)
+        {
+            printf("ERR: No action type matched '%s'\n", buffer);
+            return false;
+            // not found
+        }
+    }
+
+    switch (replay.nextEntry.type)
+    {
+        case BUTTON_PRESS:
+        case BUTTON_RELEASE:
+        {
+            if (1 != fscanf(replay.file, "%63s\n", buffer))
+            {
+                printf("ERR: Can't read button name\n");
+                return false;
+            }
+
+            for (uint8_t i = 0; i < 8; i++)
+            {
+                buttonBit_t button = (1 << i);
+                if (!strncmp(replayButtonNames[i], buffer, sizeof(buffer) - 1))
+                {
+                    replay.nextEntry.buttonVal = button;
+                    break;
+                }
+
+                if (i == 7)
+                {
+                // Should have broken by now, throw error
+                    printf("ERR: Can't find button matching '%s'\n", buffer);
+                    return false;
+                }
+            }
+
+            break;
+        }
+
+        case TOUCH_PHI:
+        case TOUCH_R:
+        case TOUCH_INTENSITY:
+        {
+            if (1 != fscanf(replay.file, "%"PRId32"\n", &replay.nextEntry.touchVal))
+            {
+                return false;
+            }
+            break;
+        }
+
+        case ACCEL_X:
+        case ACCEL_Y:
+        case ACCEL_Z:
+        {
+            if (1 != fscanf(replay.file, "%hd\n", &replay.nextEntry.accelVal))
+            {
+                return false;
+            }
+            break;
+        }
+
+        default:
+        {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+static void writeEntry(const replayEntry_t* entry)
+{
+    char buffer[256];
+    char* ptr = buffer;
+#define BUFSIZE (buffer + sizeof(buffer) - 1 - ptr)
+
+    // Write key (frame/time)
+    if (replay.useFrames)
+    {
+        ptr += snprintf(ptr, BUFSIZE, "%"PRIu64",", entry->frame);
+    }
+    else
+    {
+        ptr += snprintf(ptr, BUFSIZE, "%"PRId64",", entry->time);
+    }
+
+    // Write entry type
+    ptr += snprintf(ptr, BUFSIZE, "%s,", replayLogTypeStrs[entry->type]);
+
+    switch (entry->type)
+    {
+        case BUTTON_PRESS:
+        case BUTTON_RELEASE:
+        {
+            // Find button index
+            int i = 0;
+            while ((1 << i) != entry->buttonVal && i < 7) {
+                i++;
+            }
+
+            // TODO: Check for invalid button index?
+            ptr += snprintf(ptr, BUFSIZE, "%s\n", replayButtonNames[i]);
+            break;
+        }
+
+        case TOUCH_PHI:
+        case TOUCH_R:
+        case TOUCH_INTENSITY:
+        {
+            ptr += snprintf(ptr, BUFSIZE, "%"PRId32"\n", entry->touchVal);
+            break;
+        }
+
+        case ACCEL_X:
+        case ACCEL_Y:
+        case ACCEL_Z:
+        {
+            ptr += snprintf(ptr, BUFSIZE, "%"PRId16"\n", entry->accelVal);
+            break;
+        }
+    }
+
+    fwrite(buffer, 1, strlen(buffer), replay.file);
+}

--- a/emulator/src/extensions/replay/ext_replay.h
+++ b/emulator/src/extensions/replay/ext_replay.h
@@ -1,0 +1,3 @@
+#include "emu_ext.h"
+
+extern emuExtension_t replayEmuExtension;

--- a/emulator/src/extensions/replay/ext_replay.h
+++ b/emulator/src/extensions/replay/ext_replay.h
@@ -1,6 +1,62 @@
 /*! \file ext_replay.h
  *
+ * \section ext_replay Replay Emulator Extension
  *
+ * The replay extension allows you to record swadge inputs -- button presses, touchpad inputs,
+ * and accelerometer readings -- to a file, and then play them back later. And when playing back
+ * inputs, several special actions are also supported: starting fuzzing, taking a screenshot,
+ * and quitting the emulator. These must be manually added to a recording file, but they can used
+ * to automatically target fuzzing to a specific screen, or to automatically generate a screenshot
+ * of a specific screen.
+ *
+ * \section ext_format Recording File Format
+ * If not given a custom name, recording files will be created in the current directory with the
+ * name 'rec-TIMESTAMP.csv' As suggested by the name, this is simply a CSV file. The first line
+ * contains the header, which specifies three columns: Time, Type, and Value. The rest of the lines
+ * will be the individual input values or special actions.
+ *
+ * The first column, `Time`, is the timestamp, in microseconds, of the input. The next column,
+ * `Type`, is the type of data or the special action to perform. Possible options are: `BtnDown`,
+ * `BtnUp`, `TouchPhi`, `TouchR`, `TouchI`, `AccelX`, `AccelY`, or `AccelZ`, and `Screenshot`,
+ * `Fuzz`, and `Quit`.
+ *
+ * The third column, `Value`, depends on the value of the `Type` column. For `BtnDown` and `BtnUp`,
+ * this is the name of the button: `A`, `B`, `Up`, `Down`, `Left`, `Right`, `Select`, or `Start`.
+ * For all `Touch*` and `Accel*` types, the value is an integer. For `Screenshot`, the third column
+ * is the filename for the screenshot, or it may be left blank for an automatically generated filename.
+ * For `Quit` and `Fuzz`, the third column is completely ignored.
+ *
+ * The following example recording file will generate a few button presses and touch events, then take
+ * a screenshot after about 4 seconds, begin fuzzing until 10 seconds have passed, and then take another
+ * screenshot before closing the emulator.
+ * \code{.csv}
+ * Time,Type,Value
+ * 23558,AccelZ,242
+ * 500383,BtnDown,A
+ * 565291,BtnUp,A
+ * 1498312,TouchPhi,319
+ * 1498312,TouchR,132
+ * 1498312,TouchI,1024
+ * 1532527,TouchPhi,328
+ * 1532527,TouchR,146
+ * 1582694,TouchPhi,12
+ * 1582694,TouchR,350
+ * 1749475,TouchPhi,0
+ * 1749475,TouchR,0
+ * 1749475,TouchI,0
+ * 2582065,BtnDown,Up
+ * 2631439,BtnUp,Up
+ * 2832071,BtnDown,Down
+ * 2882992,BtnUp,Down
+ * 3518793,BtnDown,Right
+ * 3568577,BtnUp,Right
+ * 3636235,BtnDown,Left
+ * 3652407,BtnUp,Left
+ * 3735765,Screenshot,beforeFuzz.bmp
+ * 3802347,Fuzz,
+ * 10000000,Screenshot,afterFuzz.bmp
+ * 10000000,Quit,
+ * \endcode
  */
 
 #include "emu_ext.h"

--- a/emulator/src/extensions/replay/ext_replay.h
+++ b/emulator/src/extensions/replay/ext_replay.h
@@ -1,3 +1,10 @@
+/*! \file ext_replay.h
+ *
+ *
+ */
+
 #include "emu_ext.h"
 
 extern emuExtension_t replayEmuExtension;
+
+bool takeScreenshot(const char* name);

--- a/emulator/src/extensions/replay/ext_replay.h
+++ b/emulator/src/extensions/replay/ext_replay.h
@@ -5,9 +5,9 @@
  * The replay extension allows you to record swadge inputs -- button presses, touchpad inputs,
  * and accelerometer readings -- to a file, and then play them back later. And when playing back
  * inputs, several special actions are also supported: starting fuzzing, taking a screenshot,
- * and quitting the emulator. These must be manually added to a recording file, but they can used
- * to automatically target fuzzing to a specific screen, or to automatically generate a screenshot
- * of a specific screen.
+ * changing modes, and quitting the emulator. These must be manually added to a recording file,
+ * but they can used to automatically target fuzzing to a specific screen, or to automatically
+ * generate a screenshot of a specific screen.
  *
  * \section ext_format Recording File Format
  * If not given a custom name, recording files will be created in the current directory with the
@@ -18,17 +18,18 @@
  * The first column, `Time`, is the timestamp, in microseconds, of the input. The next column,
  * `Type`, is the type of data or the special action to perform. Possible options are: `BtnDown`,
  * `BtnUp`, `TouchPhi`, `TouchR`, `TouchI`, `AccelX`, `AccelY`, or `AccelZ`, and `Screenshot`,
- * `Fuzz`, and `Quit`.
+ * `Fuzz`, `SetMode`, and `Quit`.
  *
  * The third column, `Value`, depends on the value of the `Type` column. For `BtnDown` and `BtnUp`,
  * this is the name of the button: `A`, `B`, `Up`, `Down`, `Left`, `Right`, `Select`, or `Start`.
  * For all `Touch*` and `Accel*` types, the value is an integer. For `Screenshot`, the third column
  * is the filename for the screenshot, or it may be left blank for an automatically generated filename.
- * For `Quit` and `Fuzz`, the third column is completely ignored.
+ * For `SetMode`, the value is the name of the mode to switch to. And, for `Quit` and `Fuzz`, the third
+ * column is completely ignored.
  *
- * The following example recording file will generate a few button presses and touch events, then take
- * a screenshot after about 4 seconds, begin fuzzing until 10 seconds have passed, and then take another
- * screenshot before closing the emulator.
+ * The following example recording file will generate a few button presses and touch events, then after
+ * about 4 seconds, switch to Pong, take a screenshot, begin fuzzing until 10 seconds have passed, and
+ * finally take another screenshot before closing the emulator.
  * \code{.csv}
  * Time,Type,Value
  * 23558,AccelZ,242
@@ -52,6 +53,7 @@
  * 3568577,BtnUp,Right
  * 3636235,BtnDown,Left
  * 3652407,BtnUp,Left
+ * 3735765,SetMode,Pong
  * 3735765,Screenshot,beforeFuzz.bmp
  * 3802347,Fuzz,
  * 10000000,Screenshot,afterFuzz.bmp


### PR DESCRIPTION
### Description

This adds functionality to the emulator for recording inputs to a file and playing them back later. It also supports some extra non-input actions when playing back a recording, such as enabling fuzzing, saving a screenshot, force-changing modes, and exiting the emulator.

Oh, and it adds a headless argument to have a hidden window, but I'm not sure if that works outside of Linux / for all rawdraw drivers.

### Test Instructions

Record inputs by running `swadge_emulator --record recording.csv` or just `swadge_emulator --record` (which should name the file `rec-xxxxxxx.csv`). When you're done, close the emulator and the file should now be full of inputs!

Play back that file with `swadge_emulator --playback recording.csv` and it should do exactly the same things as when recorded.

Edit the recording, and try adding these lines to the end:
```
14500000,SetMode,Touch Test
15000000,Screenshot,
15000000,Fuzz,
17500000,Screenshot,filename.bmp
20000000,Quit,
```
If you play back the recording with `swadge_emulator --playback recording.csv` again, it should repeat your inputs and then, after the original script ends, will wait until almost 15 seconds have passed and switch to the touch test mode, take a screenshot (`screenshot-xx.bmp`), begin fuzzing, then take another screenshot 2.5s later, and finally quit after waiting another 2.5s. You should see a `screenshot-xx.bmp` and `filename.bmp` in your working directory, and they should look correct.

Then, delete the screenshots and run the emulator again with `--headless` as well; it should do everything the same, but no window should appear. The screenshots should still be generated and look normal.

### Ticket Links

<!--- Link any tickets that are completed in this pull request. -->

### Readiness Checklist
- [x] I have run `make format` to format the changes
- [x] I have compiled the firmware and the changes have no warnings
- [x] I have compiled the emulator and the changes have no warnings
- [x] I have run `make cppcheck` and checked that `cppcheck_result.txt` has no warnings for the changes
- [x] I have added doxygen comments to any code used by more than one Swadge mode. This includes `/*! \file` comments with Design Philosophy, Usage, and Example sections for new headers.
- [x] I have run `make docs` and checked that `doxy_warnings.txt` has no warnings for the new code
