### PR TITLE
Fix too small buffer compile error

### DIFF
--- a/main/modes/pushy/pushy.c
+++ b/main/modes/pushy/pushy.c
@@ -489,8 +489,8 @@ void showDigit(uint8_t number, uint8_t colorIndex, uint8_t digitIndexFromLeastSi
 
     // Convert the number to a string
     paletteColor_t color;
-    char numberAsStr[2];
-    snprintf(numberAsStr, 2, "%1" PRIu8, number);
+    char numberAsStr[4];
+    snprintf(numberAsStr, sizeof(numberAsStr), "%1" PRIu8, number);
 
     // Apply weed and rainbow effects, or if no effects, get the current color for this digit
     if (pushy->weedDigits[NUM_DIGITS - 1 - digitIndexFromLeastSignificant])


### PR DESCRIPTION
### Description

<!--- What was added and/or fixed in this pull request? -->

Fixes this compile error that happens in main:

```
main/modes/pushy/pushy.c: In function ‘showDigit’:
main/modes/pushy/pushy.c:493:30: error: ‘%1u’ directive output may be truncated writing between 1 and 3 bytes into a region of size 2 [-Werror=format-truncation=]
  493 |     snprintf(numberAsStr, 2, "%1" PRIu8, number);
      |                              ^~~~
main/modes/pushy/pushy.c:493:31: note: format string is defined here
  493 |     snprintf(numberAsStr, 2, "%1" PRIu8, number);
main/modes/pushy/pushy.c:493:30: note: directive argument in the range [0, 255]
  493 |     snprintf(numberAsStr, 2, "%1" PRIu8, number);
      |                              ^~~~
main/modes/pushy/pushy.c:493:5: note: ‘snprintf’ output between 2 and 4 bytes into a destination of size 2
  493 |     snprintf(numberAsStr, 2, "%1" PRIu8, number);
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

### Test Instructions

Compile the emulator without the error!

### Ticket Links

<!--- Link any tickets that are completed in this pull request. -->

### Readiness Checklist
- [x] I have run `make format` to format the changes
- [x] I have compiled the firmware and the changes have no warnings
- [x] I have compiled the emulator and the changes have no warnings
- [x] I have run `make cppcheck` and checked that `cppcheck_result.txt` has no warnings for the changes
- [x] I have added doxygen comments to any code used by more than one Swadge mode. This includes `/*! \file` comments with Design Philosophy, Usage, and Example sections for new headers.
- [x] I have run `make docs` and checked that `doxy_warnings.txt` has no warnings for the new code
