### PR TITLE
Keymap Emulator Extension

### DIFF
--- a/emulator/src/extensions/emu_args.c
+++ b/emulator/src/extensions/emu_args.c
@@ -124,6 +124,7 @@ static const char argFuzzTouch[]   = "fuzz-touch";
 static const char argFuzzMotion[]  = "fuzz-motion";
 static const char argHeadless[]    = "headless";
 static const char argHideLeds[]    = "hide-leds";
+static const char argKeymap[]      = "keymap";
 static const char argLock[]        = "lock";
 static const char argMode[]        = "mode";
 static const char argModeSwitch[]  = "mode-switch";
@@ -147,6 +148,7 @@ static const struct option options[] =
     { argFuzzMotion,  optional_argument, (int*)&emulatorArgs.fuzzMotion,   true },
     { argHeadless,    no_argument,       (int*)&emulatorArgs.headless,     true },
     { argHideLeds,    no_argument,       (int*)&emulatorArgs.hideLeds,     true },
+    { argKeymap,      required_argument, NULL,                             'k'  },
     { argLock,        no_argument,       (int*)&emulatorArgs.lock,         true },
     { argMode,        required_argument, NULL,                             'm'  },
     { argPlayback,    required_argument, (int*)&emulatorArgs.playback,     'p'  },
@@ -156,7 +158,6 @@ static const struct option options[] =
     { argTouch,       no_argument,       (int*)&emulatorArgs.emulateTouch, true },
     { argHelp,        no_argument,       NULL,                             'h'  },
     { argUsage,       no_argument,       NULL,                             0    },
-
     {0},
 };
 
@@ -172,6 +173,7 @@ static const optDoc_t argDocs[] =
     { 0,  argFuzzMotion,  "y|n",   "Set whether motion inputs are fuzzed" },
     { 0,  argHeadless,    NULL,    "Runs the emulator without a window." },
     { 0,  argHideLeds,    NULL,    "Don't draw simulated LEDs next to the display" },
+    {'k', argKeymap,     "LAYOUT", "Use an alternative keymap. LAYOUT can be azerty, colemak, dvorak, or dvp"},
     {'l', argLock,        NULL,    "Lock the emulator in the start mode" },
     {'m', argMode,        "MODE",  "Start the emulator in the swadge mode MODE instead of the main menu"},
     { 0,  argModeSwitch,  "TIME",  "Enable or set the timer to switch modes automatically" },
@@ -241,12 +243,17 @@ static bool handleArgument(const char* optName, const char* arg, int optVal)
         }
         return true;
     }
-    else if (argMode == optName)
+    else if (argKeymap == optName)
     {
         if (arg)
         {
-            emulatorArgs.startMode = arg;
+            emulatorArgs.keymap = arg;
         }
+        return true;
+    }
+    else if (argMode == optName)
+    {
+        emulatorArgs.startMode = arg;
     }
     else if (argModeList == optName)
     {

--- a/emulator/src/extensions/emu_args.c
+++ b/emulator/src/extensions/emu_args.c
@@ -173,7 +173,7 @@ static const optDoc_t argDocs[] =
     { 0,  argFuzzMotion,  "y|n",   "Set whether motion inputs are fuzzed" },
     { 0,  argHeadless,    NULL,    "Runs the emulator without a window." },
     { 0,  argHideLeds,    NULL,    "Don't draw simulated LEDs next to the display" },
-    {'k', argKeymap,     "LAYOUT", "Use an alternative keymap. LAYOUT can be azerty, colemak, dvorak, or dvp"},
+    {'k', argKeymap,     "LAYOUT", "Use an alternative keymap. LAYOUT can be azerty, colemak, or dvorak"},
     {'l', argLock,        NULL,    "Lock the emulator in the start mode" },
     {'m', argMode,        "MODE",  "Start the emulator in the swadge mode MODE instead of the main menu"},
     { 0,  argModeSwitch,  "TIME",  "Enable or set the timer to switch modes automatically" },

--- a/emulator/src/extensions/emu_ext.c
+++ b/emulator/src/extensions/emu_ext.c
@@ -16,6 +16,7 @@
 #include "ext_touch.h"
 #include "ext_leds.h"
 #include "ext_fuzzer.h"
+#include "ext_keymap.h"
 #include "ext_modes.h"
 #include "ext_replay.h"
 
@@ -28,7 +29,8 @@
 //==============================================================================
 
 static const emuExtension_t* registeredExtensions[] = {
-    &touchEmuCallback, &ledEmuExtension, &fuzzerEmuExtension, &modesEmuExtension, &replayEmuExtension,
+    &touchEmuCallback, &ledEmuExtension, &fuzzerEmuExtension, &keymapEmuCallback, &modesEmuExtension,
+    &replayEmuExtension,
 };
 
 //==============================================================================

--- a/emulator/src/extensions/emu_ext.c
+++ b/emulator/src/extensions/emu_ext.c
@@ -29,8 +29,8 @@
 //==============================================================================
 
 static const emuExtension_t* registeredExtensions[] = {
-    &touchEmuCallback, &ledEmuExtension, &fuzzerEmuExtension, &keymapEmuCallback, &modesEmuExtension,
-    &replayEmuExtension,
+    &touchEmuCallback,  &ledEmuExtension,   &fuzzerEmuExtension,
+    &keymapEmuCallback, &modesEmuExtension, &replayEmuExtension,
 };
 
 //==============================================================================

--- a/emulator/src/extensions/keymap/ext_keymap.c
+++ b/emulator/src/extensions/keymap/ext_keymap.c
@@ -1,0 +1,141 @@
+#include "ext_keymap.h"
+
+#include <string.h>
+#include <stdio.h>
+
+#include "macros.h"
+
+//==============================================================================
+// Function Prototypes
+//==============================================================================
+
+static bool keymapInit(emuArgs_t* emuArgs);
+static int32_t keymapKeyCb(uint32_t keycode, bool down);
+
+//==============================================================================
+// Structs
+//==============================================================================
+
+typedef struct
+{
+    const char* name; ///< The name of the keyboard layout
+
+    union
+    {
+        /// @brief Holds each keycode in a separate char
+        struct keys
+        {
+            char up;
+            char down;
+            char left;
+            char right;
+
+            char a;
+            char b;
+
+            char start;
+            char select;
+
+            char touch1;
+            char touch2;
+            char touch3;
+            char touch4;
+            char touch5;
+        };
+
+        /// @brief Holds all keycodes in a single string
+        // These keycodes will be in the same
+        char keymap[14];
+    };
+} emuKeymap_t;
+
+//==============================================================================
+// Variables
+//==============================================================================
+
+const emuExtension_t keymapEmuCallback = {
+    .name            = "keymap",
+    .fnInitCb        = keymapInit,
+    .fnPreFrameCb    = NULL,
+    .fnPostFrameCb   = NULL,
+    .fnKeyCb         = keymapKeyCb,
+    .fnMouseMoveCb   = NULL,
+    .fnMouseButtonCb = NULL,
+    .fnRenderCb      = NULL,
+};
+
+static const emuKeymap_t keymaps[] = {
+    {.name = "qwerty", .keymap = "WSADLKOI12345"},  // QWERTY (default)
+    {.name = "azerty", .keymap = "ZSQDLKOI12345"},  // AZERTY
+    {.name = "colemak", .keymap = "WRASIEYU12345"}, // Colemak
+    {.name = "dvorak", .keymap = ",OAENTRC12345"},  // Dvorak
+    {.name = "dvp", .keymap = ",OAENTRC&[{}("},     // Programmer Dvorak
+};
+
+static const emuKeymap_t* activeKeymap = NULL;
+
+//==============================================================================
+// Functions
+//==============================================================================
+
+static bool keymapInit(emuArgs_t* emuArgs)
+{
+    if (emuArgs->keymap != NULL)
+    {
+        for (const emuKeymap_t* keymap = keymaps; keymap < (keymaps + ARRAY_SIZE(keymaps)); keymap++)
+        {
+            if (!strncmp(emuArgs->keymap, keymap->name, sizeof(keymap->name) - 1))
+            {
+                printf("Set keymap to '%s'\n", keymap->name);
+                // Set the keyboard map, we found it!
+                activeKeymap = keymap;
+
+                // Setup successful
+                return true;
+            }
+        }
+
+        if (activeKeymap == NULL)
+        {
+            // We never set a keymap
+            fprintf(stderr, "WARN: Unknown keyboard layout '%s'\n", emuArgs->keymap);
+            return false;
+        }
+    }
+
+    // No configuration found, no need to set up
+    return false;
+}
+
+static int32_t keymapKeyCb(uint32_t keycode, bool down)
+{
+    // Convert lowercase characters to their uppercase equivalents
+    if ('a' <= keycode && keycode <= 'z')
+    {
+        keycode = (keycode - 'a' + 'A');
+    }
+
+    // Check if the key matches one in the layout
+    if (activeKeymap != NULL)
+    {
+        for (uint8_t i = 0; i < 13; i++)
+        {
+            if (activeKeymap->keymap[i] == keycode)
+            {
+                // Remap onto qwerty
+                return keymaps->keymap[i];
+            }
+        }
+    }
+
+    for (uint8_t i = 0; i < 13; i++)
+    {
+        if (keymaps->keymap[i] == keycode)
+        {
+            // Stop the original key from colliding
+            return -1;
+        }
+    }
+
+    return 0;
+}

--- a/emulator/src/extensions/keymap/ext_keymap.c
+++ b/emulator/src/extensions/keymap/ext_keymap.c
@@ -23,7 +23,7 @@ typedef struct
     union
     {
         /// @brief Holds each keycode in a separate char
-        struct keys
+        struct
         {
             char up;
             char down;
@@ -35,17 +35,11 @@ typedef struct
 
             char start;
             char select;
-
-            char touch1;
-            char touch2;
-            char touch3;
-            char touch4;
-            char touch5;
         };
 
         /// @brief Holds all keycodes in a single string
-        // These keycodes will be in the same
-        char keymap[14];
+        // These keycodes will be in the same memory
+        char keymap[9];
     };
 } emuKeymap_t;
 
@@ -65,11 +59,10 @@ const emuExtension_t keymapEmuCallback = {
 };
 
 static const emuKeymap_t keymaps[] = {
-    {.name = "qwerty", .keymap = "WSADLKOI12345"},  // QWERTY (default)
-    {.name = "azerty", .keymap = "ZSQDLKOI12345"},  // AZERTY
-    {.name = "colemak", .keymap = "WRASIEYU12345"}, // Colemak
-    {.name = "dvorak", .keymap = ",OAENTRC12345"},  // Dvorak
-    {.name = "dvp", .keymap = ",OAENTRC&[{}("},     // Programmer Dvorak
+    {.name = "qwerty", .keymap = "WSADLKOI"},  // QWERTY (default)
+    {.name = "azerty", .keymap = "ZSQDLKOI"},  // AZERTY
+    {.name = "colemak", .keymap = "WRASIEYU"}, // Colemak
+    {.name = "dvorak", .keymap = ",OAENTRC"},  // Dvorak
 };
 
 static const emuKeymap_t* activeKeymap = NULL;
@@ -84,7 +77,7 @@ static bool keymapInit(emuArgs_t* emuArgs)
     {
         for (const emuKeymap_t* keymap = keymaps; keymap < (keymaps + ARRAY_SIZE(keymaps)); keymap++)
         {
-            if (!strncmp(emuArgs->keymap, keymap->name, sizeof(keymap->name) - 1))
+            if (!strncmp(emuArgs->keymap, keymap->name, strlen(emuArgs->keymap)))
             {
                 printf("Set keymap to '%s'\n", keymap->name);
                 // Set the keyboard map, we found it!
@@ -118,7 +111,7 @@ static int32_t keymapKeyCb(uint32_t keycode, bool down)
     // Check if the key matches one in the layout
     if (activeKeymap != NULL)
     {
-        for (uint8_t i = 0; i < 13; i++)
+        for (uint8_t i = 0; i < 8; i++)
         {
             if (activeKeymap->keymap[i] == keycode)
             {
@@ -128,7 +121,7 @@ static int32_t keymapKeyCb(uint32_t keycode, bool down)
         }
     }
 
-    for (uint8_t i = 0; i < 13; i++)
+    for (uint8_t i = 0; i < 8; i++)
     {
         if (keymaps->keymap[i] == keycode)
         {

--- a/emulator/src/extensions/keymap/ext_keymap.h
+++ b/emulator/src/extensions/keymap/ext_keymap.h
@@ -1,0 +1,20 @@
+/**
+ * @file emu_keymap.h
+ * @author dylwhich (dylan@whichard.com)
+ * @brief This file contains an extension that remaps keybinds for alternate layouts
+ * @date 2023-08-05
+ *
+ */
+#pragma once
+
+//==============================================================================
+// Includes
+//==============================================================================
+
+#include "emu_ext.h"
+
+//==============================================================================
+// Variables
+//==============================================================================
+
+const extern emuExtension_t keymapEmuCallback;

--- a/main/swadge2024.c
+++ b/main/swadge2024.c
@@ -378,7 +378,6 @@ void app_main(void)
                 {
                     // Call the overlay mode's main loop if there is one
                     quickSettingsMode.fnMainLoop(tNowUs - tLastMainLoopCall);
-                    
                 }
                 else
                 {
@@ -387,7 +386,6 @@ void app_main(void)
                 }
                 tLastMainLoopCall = tNowUs;
             }
-
 
             // If the menu button is being held
             if (0 != timeExitPressed && !showQuickSettings)

--- a/main/swadge2024.h
+++ b/main/swadge2024.h
@@ -29,22 +29,22 @@
  * \c demo in the example below.
  *
  * \section swadgeMode_example Example
- * 
+ *
  * Adding a mode to the CMakeFile requires adding two separate lines in the idf_component_register section.
- * 
+ *
  * \c
  * "modes/pong/pong.c"
  * \endcode
  *
  * under the SRCS section and
- * 
+ *
  * \c
  * "modes/pong"
  * \endcode
- * 
+ *
  * under the INCLUDES section.
- * 
- * 
+ *
+ *
  * Function prototypes must be declared before using them to initialize function pointers:
  * \code{.c}
  * // It's good practice to declare immutable strings as const so they get placed in ROM, not RAM


### PR DESCRIPTION
### Description

Adds an extension that lets you use the emulator with several alterate keyboard layouts, for mostly selfish reasons:
* AZERTY
* Colemak
* Dvorak

### Test Instructions

Run the emulator with --keymap 'azerty' or -k dvorak  or -k colemak and see that it uses different keybindings.

### Ticket Links

<!--- Link any tickets that are completed in this pull request. -->

### Readiness Checklist
- [x] I have run `make format` to format the changes
- [x] I have compiled the firmware and the changes have no warnings
- [x] I have compiled the emulator and the changes have no warnings
- [x] I have run `make cppcheck` and checked that `cppcheck_result.txt` has no warnings for the changes
- [x] I have added doxygen comments to any code used by more than one Swadge mode. This includes `/*! \file` comments with Design Philosophy, Usage, and Example sections for new headers.
- [x] I have run `make docs` and checked that `doxy_warnings.txt` has no warnings for the new code
