### PR TITLE
Fix missing return messing up menus

### DIFF
--- a/main/menu/menu.c
+++ b/main/menu/menu.c
@@ -773,8 +773,7 @@ menu_t* menuButton(menu_t* menu, buttonEvt_t evt)
             }
             case PB_A:
             {
-                menuSelectCurrentItem(menu);
-                break;
+                return menuSelectCurrentItem(menu);
             }
             case PB_B:
             {


### PR DESCRIPTION
### Description

<!--- What was added and/or fixed in this pull request? -->

Fixes a bug where selecting a menu item with `PB_A` or going up with `PB_B` would call the callback, but not change menu levels properly (but using left and right would).

### Test Instructions

<!--- How was this tested? -->
On the main menu, scroll down to Settings and press A. It should open the settings menu. In the settings menu, press B and you should go back to the main menu.

### Ticket Links

<!--- Link any tickets that are completed in this pull request. -->

### Readiness Checklist
- [x] I have run `make format` to format the changes
- [x] I have compiled the firmware and the changes have no warnings
- [x] I have compiled the emulator and the changes have no warnings
- [x] I have run `make cppcheck` and checked that `cppcheck_result.txt` has no warnings for the changes
- [x] I have added doxygen comments to any code used by more than one Swadge mode. This includes `/*! \file` comments with Design Philosophy, Usage, and Example sections for new headers.
- [x] I have run `make docs` and checked that `doxy_warnings.txt` has no warnings for the new code
