### PR TITLE
Ninth led

### DIFF
--- a/components/hdw-led/hdw-led.c
+++ b/components/hdw-led/hdw-led.c
@@ -20,9 +20,9 @@
 // Variables
 //==============================================================================
 
-static rmt_channel_handle_t led_chan    = NULL;
-static rmt_encoder_handle_t led_encoder = NULL;
-static uint8_t ledBrightness            = 0;
+static rmt_channel_handle_t led_chan        = NULL;
+static rmt_encoder_handle_t led_encoder     = NULL;
+static uint8_t ledBrightness                = 0;
 static led_t localLeds[CONFIG_NUM_LEDS + 1] = {0};
 
 //==============================================================================
@@ -122,13 +122,13 @@ esp_err_t setLeds(led_t* leds, uint8_t numLeds)
     }
 
     // If all eight LEDs are being set, but not the 9th
-    if(CONFIG_NUM_LEDS == numLeds)
+    if (CONFIG_NUM_LEDS == numLeds)
     {
         // Set the 9th LED to the average of the 6th, 7th, and 8th
         int32_t avgR = 0;
         int32_t avgG = 0;
         int32_t avgB = 0;
-        for(int32_t lIdx = 5; lIdx < 8; lIdx++)
+        for (int32_t lIdx = 5; lIdx < 8; lIdx++)
         {
             avgR += leds[lIdx].r;
             avgG += leds[lIdx].g;

--- a/components/hdw-led/include/hdw-led.h
+++ b/components/hdw-led/include/hdw-led.h
@@ -25,6 +25,10 @@
  * Brightness is adjusted per-color-channel, so dimming may produce different colors.
  * setLedBrightnessSetting() should be called instead if the brightness change should be persistent through reboots.
  *
+ * Even though \c CONFIG_NUM_LEDS declares eight LEDs, there is a ninth LED which is controllable. By default, setting
+ * \c CONFIG_NUM_LEDS LEDs will automatically set the ninth to the average of the sixth, seventh, and eighth, which
+ * surround it on the PCB. To set the ninth LED, set `CONFIG_NUM_LEDS + 1` LEDs.
+ *
  * \section led_example Example
  *
  * Set the LEDs to a rough rainbow:

--- a/components/hdw-mic/hdw-mic.c
+++ b/components/hdw-mic/hdw-mic.c
@@ -62,7 +62,7 @@ void initMic(gpio_num_t gpio)
         adc_digi_pattern_config_t adc_pattern[SOC_ADC_PATT_LEN_MAX] = {0};
 
         // Configure the ADC pattern. We only configure a single channel
-        adc_pattern[0].atten     = ADC_ATTEN_DB_0;
+        adc_pattern[0].atten     = ADC_ATTEN_DB_11;
         adc_pattern[0].channel   = channel;
         adc_pattern[0].unit      = unit;
         adc_pattern[0].bit_width = SOC_ADC_DIGI_MAX_BITWIDTH;


### PR DESCRIPTION
### Description

Automatic 9th LED lighting

### Test Instructions

Run LED patterns on actual hardware, validate 9th LED looks sane

### Ticket Links

n/a

### Readiness Checklist
- [x] I have run `make format` to format the changes
- [x] I have compiled the firmware and the changes have no warnings
- [x] I have compiled the emulator and the changes have no warnings
- [x] I have run `make cppcheck` and checked that `cppcheck_result.txt` has no warnings for the changes
- [x] I have added doxygen comments to any code used by more than one Swadge mode. This includes `/*! \file` comments with Design Philosophy, Usage, and Example sections for new headers.
- [x] I have run `make docs` and checked that `doxy_warnings.txt` has no warnings for the new code
