### PR TITLE
Namespaced NVS functions

### DIFF
--- a/components/hdw-nvs/hdw-nvs.c
+++ b/components/hdw-nvs/hdw-nvs.c
@@ -114,8 +114,33 @@ bool eraseNvs(void)
  */
 bool readNvs32(const char* key, int32_t* outVal)
 {
+    return readNamespaceNvs32(NVS_NAMESPACE_NAME, key, outVal);
+}
+
+/**
+ * @brief Write a 32 bit value to NVS with a given string key
+ *
+ * @param key The key for the value to write
+ * @param val The value to write
+ * @return true if the value was written, false if it was not
+ */
+bool writeNvs32(const char* key, int32_t val)
+{
+    return writeNamespaceNvs32(NVS_NAMESPACE_NAME, key, val);
+}
+
+/**
+ * @brief Read a 32 bit value from NVS with a given string key
+ *
+ * @param namespace The NVS namespace to use
+ * @param key The key for the value to read
+ * @param outVal The value that was read
+ * @return true if the value was read, false if it was not
+ */
+bool readNamespaceNvs32(const char* namespace, const char* key, int32_t* outVal)
+{
     nvs_handle_t handle;
-    esp_err_t openErr = nvs_open(NVS_NAMESPACE_NAME, NVS_READONLY, &handle);
+    esp_err_t openErr = nvs_open(namespace, NVS_READONLY, &handle);
     switch (openErr)
     {
         case ESP_OK:
@@ -162,14 +187,15 @@ bool readNvs32(const char* key, int32_t* outVal)
 /**
  * @brief Write a 32 bit value to NVS with a given string key
  *
+ * @param namespace The NVS namespace to use
  * @param key The key for the value to write
  * @param val The value to write
  * @return true if the value was written, false if it was not
  */
-bool writeNvs32(const char* key, int32_t val)
+bool writeNamespaceNvs32(const char* namespace, const char* key, int32_t val)
 {
     nvs_handle_t handle;
-    esp_err_t openErr = nvs_open(NVS_NAMESPACE_NAME, NVS_READWRITE, &handle);
+    esp_err_t openErr = nvs_open(namespace, NVS_READWRITE, &handle);
     switch (openErr)
     {
         case ESP_OK:
@@ -371,8 +397,20 @@ bool writeNamespaceNvsBlob(const char* namespace, const char* key, const void* v
  */
 bool eraseNvsKey(const char* key)
 {
+    return eraseNamespaceNvsKey(NVS_NAMESPACE_NAME, key);
+}
+
+/**
+ * @brief Delete the value with the given key from NVS
+ *
+ * @param namespace The NVS namespace to use
+ * @param key The NVS key to be deleted
+ * @return true if the value was deleted, false if it was not
+ */
+bool eraseNamespaceNvsKey(const char* namespace, const char* key)
+{
     nvs_handle_t handle;
-    esp_err_t openErr = nvs_open(NVS_NAMESPACE_NAME, NVS_READWRITE, &handle);
+    esp_err_t openErr = nvs_open(namespace, NVS_READWRITE, &handle);
     switch (openErr)
     {
         case ESP_OK:
@@ -446,6 +484,23 @@ bool readNvsStats(nvs_stats_t* outStats)
 }
 
 /**
+ * @brief Read info about each used entry in the default NVS namespace. Typically, this should be called once with NULL passed for
+ * outEntryInfos, to get the value for numEntryInfos, then memory for outEntryInfos should be allocated, then this
+ * should be called again
+ *
+ * @param outStats If not `NULL`, the NVS stats struct will be written to this memory. It must be allocated before
+ * calling readAllNvsEntryInfos()
+ * @param outEntryInfos A pointer to an array of NVS entry info structs will be written to this memory
+ * @param numEntryInfos If outEntryInfos is `NULL`, this will be set to the length of the given key. Otherwise, it is
+ * the number of entry infos to read
+ * @return true if the entry infos were read, false if they were not
+ */
+bool readAllNvsEntryInfos(nvs_stats_t* outStats, nvs_entry_info_t** outEntryInfos, size_t* numEntryInfos)
+{
+    return readNamespaceNvsEntryInfos(NVS_NAMESPACE_NAME, outStats, outEntryInfos, numEntryInfos);
+}
+
+/**
  * @brief Read info about each used entry in a specific NVS namespace. Typically, this should be called once with NULL passed for
  * outEntryInfos, to get the value for numEntryInfos, then memory for outEntryInfos should be allocated, then this
  * should be called again
@@ -502,21 +557,4 @@ bool readNamespaceNvsEntryInfos(const char* namespace, nvs_stats_t* outStats, nv
         *numEntryInfos = i;
     }
     return true;
-}
-
-/**
- * @brief Read info about each used entry in the default NVS namespace. Typically, this should be called once with NULL passed for
- * outEntryInfos, to get the value for numEntryInfos, then memory for outEntryInfos should be allocated, then this
- * should be called again
- *
- * @param outStats If not `NULL`, the NVS stats struct will be written to this memory. It must be allocated before
- * calling readAllNvsEntryInfos()
- * @param outEntryInfos A pointer to an array of NVS entry info structs will be written to this memory
- * @param numEntryInfos If outEntryInfos is `NULL`, this will be set to the length of the given key. Otherwise, it is
- * the number of entry infos to read
- * @return true if the entry infos were read, false if they were not
- */
-bool readAllNvsEntryInfos(nvs_stats_t* outStats, nvs_entry_info_t** outEntryInfos, size_t* numEntryInfos)
-{
-    return readNamespaceNvsEntryInfos(NVS_NAMESPACE_NAME, outStats, outEntryInfos, numEntryInfos);
 }

--- a/components/hdw-nvs/hdw-nvs.c
+++ b/components/hdw-nvs/hdw-nvs.c
@@ -484,9 +484,9 @@ bool readNvsStats(nvs_stats_t* outStats)
 }
 
 /**
- * @brief Read info about each used entry in the default NVS namespace. Typically, this should be called once with NULL passed for
- * outEntryInfos, to get the value for numEntryInfos, then memory for outEntryInfos should be allocated, then this
- * should be called again
+ * @brief Read info about each used entry in the default NVS namespace. Typically, this should be called once with NULL
+ * passed for outEntryInfos, to get the value for numEntryInfos, then memory for outEntryInfos should be allocated, then
+ * this should be called again
  *
  * @param outStats If not `NULL`, the NVS stats struct will be written to this memory. It must be allocated before
  * calling readAllNvsEntryInfos()
@@ -501,9 +501,9 @@ bool readAllNvsEntryInfos(nvs_stats_t* outStats, nvs_entry_info_t** outEntryInfo
 }
 
 /**
- * @brief Read info about each used entry in a specific NVS namespace. Typically, this should be called once with NULL passed for
- * outEntryInfos, to get the value for numEntryInfos, then memory for outEntryInfos should be allocated, then this
- * should be called again
+ * @brief Read info about each used entry in a specific NVS namespace. Typically, this should be called once with NULL
+ * passed for outEntryInfos, to get the value for numEntryInfos, then memory for outEntryInfos should be allocated, then
+ * this should be called again
  *
  * @param namespace The name of the NVS namespace to use
  * @param outStats If not `NULL`, the NVS stats struct will be written to this memory. It must be allocated before
@@ -513,7 +513,8 @@ bool readAllNvsEntryInfos(nvs_stats_t* outStats, nvs_entry_info_t** outEntryInfo
  * the number of entry infos to read
  * @return true if the entry infos were read, false if they were not
  */
-bool readNamespaceNvsEntryInfos(const char* namespace, nvs_stats_t* outStats, nvs_entry_info_t** outEntryInfos, size_t* numEntryInfos)
+bool readNamespaceNvsEntryInfos(const char* namespace, nvs_stats_t* outStats, nvs_entry_info_t** outEntryInfos,
+                                size_t* numEntryInfos)
 {
     // If the user doesn't want to receive the stats, only use them internally
     bool freeOutStats = false;

--- a/components/hdw-nvs/include/hdw-nvs.h
+++ b/components/hdw-nvs/include/hdw-nvs.h
@@ -77,6 +77,7 @@ bool eraseNvsKey(const char* key);
 bool eraseNamespaceNvsKey(const char* namespace, const char* key);
 bool readNvsStats(nvs_stats_t* outStats);
 bool readAllNvsEntryInfos(nvs_stats_t* outStats, nvs_entry_info_t** outEntryInfos, size_t* numEntryInfos);
-bool readNamespaceNvsEntryInfos(const char* namespace, nvs_stats_t* outStats, nvs_entry_info_t** outEntryInfos, size_t* numEntryInfos);
+bool readNamespaceNvsEntryInfos(const char* namespace, nvs_stats_t* outStats, nvs_entry_info_t** outEntryInfos,
+                                size_t* numEntryInfos);
 
 #endif

--- a/components/hdw-nvs/include/hdw-nvs.h
+++ b/components/hdw-nvs/include/hdw-nvs.h
@@ -69,8 +69,11 @@ bool readNvs32(const char* key, int32_t* outVal);
 bool writeNvs32(const char* key, int32_t val);
 bool readNvsBlob(const char* key, void* out_value, size_t* length);
 bool writeNvsBlob(const char* key, const void* value, size_t length);
+bool readNamespaceNvsBlob(const char* namespace, const char* key, void* out_value, size_t* length);
+bool writeNamespaceNvsBlob(const char* namespace, const char* key, const void* value, size_t length);
 bool eraseNvsKey(const char* key);
 bool readNvsStats(nvs_stats_t* outStats);
 bool readAllNvsEntryInfos(nvs_stats_t* outStats, nvs_entry_info_t** outEntryInfos, size_t* numEntryInfos);
+bool readNamespaceNvsEntryInfos(const char* namespace, nvs_stats_t* outStats, nvs_entry_info_t** outEntryInfos, size_t* numEntryInfos);
 
 #endif

--- a/components/hdw-nvs/include/hdw-nvs.h
+++ b/components/hdw-nvs/include/hdw-nvs.h
@@ -56,7 +56,7 @@
 
 #define NVS_PART_NAME_MAX_SIZE 16        /*!< maximum length of partition name (excluding null terminator) */
 #define NVS_KEY_NAME_MAX_SIZE  16        /*!< Maximal length of NVS key name (including null terminator) */
-#define NVS_NAMESPACE_NAME     "storage" /*!< The namespace used for NVS */
+#define NVS_NAMESPACE_NAME     "storage" /*!< The default namespace used for NVS */
 
 //==============================================================================
 // Function Prototypes
@@ -67,11 +67,14 @@ bool deinitNvs(void);
 bool eraseNvs(void);
 bool readNvs32(const char* key, int32_t* outVal);
 bool writeNvs32(const char* key, int32_t val);
+bool readNamespaceNvs32(const char* namespace, const char* key, int32_t* outVal);
+bool writeNamespaceNvs32(const char* namespace, const char* key, int32_t val);
 bool readNvsBlob(const char* key, void* out_value, size_t* length);
 bool writeNvsBlob(const char* key, const void* value, size_t length);
 bool readNamespaceNvsBlob(const char* namespace, const char* key, void* out_value, size_t* length);
 bool writeNamespaceNvsBlob(const char* namespace, const char* key, const void* value, size_t length);
 bool eraseNvsKey(const char* key);
+bool eraseNamespaceNvsKey(const char* namespace, const char* key);
 bool readNvsStats(nvs_stats_t* outStats);
 bool readAllNvsEntryInfos(nvs_stats_t* outStats, nvs_entry_info_t** outEntryInfos, size_t* numEntryInfos);
 bool readNamespaceNvsEntryInfos(const char* namespace, nvs_stats_t* outStats, nvs_entry_info_t** outEntryInfos, size_t* numEntryInfos);

--- a/emulator/src/components/hdw-nvs/hdw-nvs.c
+++ b/emulator/src/components/hdw-nvs/hdw-nvs.c
@@ -126,6 +126,31 @@ bool eraseNvs(void)
  */
 bool readNvs32(const char* key, int32_t* outVal)
 {
+    return readNamespaceNvs32(NVS_NAMESPACE_NAME, key, outVal);
+}
+
+/**
+ * @brief Write a 32 bit value to NVS with a given string key
+ *
+ * @param key The key for the value to write
+ * @param val The value to write
+ * @return true if the value was written, false if it was not
+ */
+bool writeNvs32(const char* key, int32_t val)
+{
+    return writeNamespaceNvs32(NVS_NAMESPACE_NAME, key, val);
+}
+
+/**
+ * @brief Read a 32 bit value from NVS with a given string key
+ *
+ * @param namespace The NVS namespace to use
+ * @param key The key for the value to read
+ * @param outVal The value that was read
+ * @return true if the value was read, false if it was not
+ */
+bool readNamespaceNvs32(const char* namespace, const char* key, int32_t* outVal)
+{
     // Open the file
     FILE* nvsFile = fopen(NVS_JSON_FILE, "rb");
     if (NULL != nvsFile)
@@ -147,13 +172,13 @@ bool readNvs32(const char* key, int32_t* outVal)
             cJSON* json = cJSON_Parse(fbuf);
             cJSON* jsonIter;
 
-            cJSON* namespace = cJSON_GetObjectItemCaseSensitive(json, NVS_NAMESPACE_NAME);
+            cJSON* jsonNs = cJSON_GetObjectItemCaseSensitive(json, namespace);
 
-            if (cJSON_IsObject(namespace))
+            if (cJSON_IsObject(jsonNs))
             {
                 // Find the requested key
                 char* current_key = NULL;
-                cJSON_ArrayForEach(jsonIter, namespace)
+                cJSON_ArrayForEach(jsonIter, jsonNs)
                 {
                     current_key = jsonIter->string;
                     if (current_key != NULL)
@@ -182,11 +207,12 @@ bool readNvs32(const char* key, int32_t* outVal)
 /**
  * @brief Write a 32 bit value to NVS with a given string key
  *
+ * @param namespace The NVS namespace to use
  * @param key The key for the value to write
  * @param val The value to write
  * @return true if the value was written, false if it was not
  */
-bool writeNvs32(const char* key, int32_t val)
+bool writeNamespaceNvs32(const char* namespace, const char* key, int32_t val)
 {
     // Open the file
     FILE* nvsFile = fopen(NVS_JSON_FILE, "rb");
@@ -208,18 +234,18 @@ bool writeNvs32(const char* key, int32_t val)
             // Parse the JSON
             cJSON* json = cJSON_Parse(fbuf);
 
-            cJSON* namespace = cJSON_GetObjectItemCaseSensitive(json, NVS_NAMESPACE_NAME);
+            cJSON* jsonNs = cJSON_GetObjectItemCaseSensitive(json, namespace);
 
-            if (NULL == namespace)
+            if (NULL == jsonNs)
             {
-                namespace = cJSON_CreateObject();
-                cJSON_AddItemToObject(json, NVS_NAMESPACE_NAME, namespace);
+                jsonNs = cJSON_CreateObject();
+                cJSON_AddItemToObject(json, namespace, jsonNs);
             }
 
             // Check if the key alredy exists
             cJSON* jsonIter;
             bool keyExists = false;
-            cJSON_ArrayForEach(jsonIter, namespace)
+            cJSON_ArrayForEach(jsonIter, jsonNs)
             {
                 if (0 == strcmp(jsonIter->string, key))
                 {
@@ -231,11 +257,11 @@ bool writeNvs32(const char* key, int32_t val)
             cJSON* jsonVal = cJSON_CreateNumber(val);
             if (keyExists)
             {
-                cJSON_ReplaceItemInObject(namespace, key, jsonVal);
+                cJSON_ReplaceItemInObject(jsonNs, key, jsonVal);
             }
             else
             {
-                cJSON_AddItemToObject(namespace, key, jsonVal);
+                cJSON_AddItemToObject(jsonNs, key, jsonVal);
             }
 
             // Write the new JSON back to the file
@@ -480,6 +506,18 @@ bool writeNvsBlob(const char* key, const void* value, size_t length)
  */
 bool eraseNvsKey(const char* key)
 {
+    return eraseNamespaceNvsKey(NVS_NAMESPACE_NAME, key);
+}
+
+/**
+ * @brief Delete the value with the given key from NVS
+ *
+ * @param namespace The NVS namespace to use
+ * @param key The NVS key to be deleted
+ * @return true if the value was deleted, false if it was not
+ */
+bool eraseNamespaceNvsKey(const char* namespace, const char* key)
+{
     // Open the file
     FILE* nvsFile = fopen(NVS_JSON_FILE, "rb");
     if (NULL != nvsFile)
@@ -504,11 +542,11 @@ bool eraseNvsKey(const char* key)
             cJSON* jsonIter;
             bool keyExists = false;
 
-            cJSON* namespace = cJSON_GetObjectItemCaseSensitive(json, NVS_NAMESPACE_NAME);
+            cJSON* jsonNs = cJSON_GetObjectItemCaseSensitive(json, namespace);
 
-            if (NULL != namespace)
+            if (NULL != jsonNs)
             {
-                cJSON_ArrayForEach(jsonIter, namespace)
+                cJSON_ArrayForEach(jsonIter, jsonNs)
                 {
                     if (0 == strcmp(jsonIter->string, key))
                     {
@@ -520,7 +558,7 @@ bool eraseNvsKey(const char* key)
             // Remove the key if it exists
             if (keyExists)
             {
-                cJSON_DeleteItemFromObject(namespace, key);
+                cJSON_DeleteItemFromObject(jsonNs, key);
             }
 
             // Write the new JSON back to the file

--- a/emulator/src/components/hdw-nvs/hdw-nvs.c
+++ b/emulator/src/components/hdw-nvs/hdw-nvs.c
@@ -692,9 +692,9 @@ bool readNvsStats(nvs_stats_t* outStats)
 }
 
 /**
- * @brief Read info about each used entry in a specific NVS namespace. Typically, this should be called once with NULL passed for
- * outEntryInfos, to get the value for numEntryInfos, then memory for outEntryInfos should be allocated, then this
- * should be called again
+ * @brief Read info about each used entry in a specific NVS namespace. Typically, this should be called once with NULL
+ * passed for outEntryInfos, to get the value for numEntryInfos, then memory for outEntryInfos should be allocated, then
+ * this should be called again
  *
  * @param namespace The name of the NVS namespace to use
  * @param outStats If not `NULL`, the NVS stats struct will be written to this memory. It must be allocated before
@@ -704,7 +704,8 @@ bool readNvsStats(nvs_stats_t* outStats)
  * the number of entry infos to read
  * @return true if the entry infos were read, false if they were not
  */
-bool readNamespaceNvsEntryInfos(const char* namespace, nvs_stats_t* outStats, nvs_entry_info_t** outEntryInfos, size_t* numEntryInfos)
+bool readNamespaceNvsEntryInfos(const char* namespace, nvs_stats_t* outStats, nvs_entry_info_t** outEntryInfos,
+                                size_t* numEntryInfos)
 {
     // Open the file
     FILE* nvsFile = fopen(NVS_JSON_FILE, "rb");
@@ -767,8 +768,8 @@ bool readNamespaceNvsEntryInfos(const char* namespace, nvs_stats_t* outStats, nv
                                 case cJSON_Number:
                                 {
 #ifdef USING_U32
-                                    // cJSON cannot store any integer larger than 2^53 or smaller than -(2^53), since those
-                                    // are the limits of a double
+                                    // cJSON cannot store any integer larger than 2^53 or smaller than -(2^53), since
+                                    // those are the limits of a double
                                     int64_t val = (int64_t)cJSON_GetNumberValue(jsonIter);
                                     if (val > INT32_MAX)
                                     {
@@ -791,8 +792,7 @@ bool readNamespaceNvsEntryInfos(const char* namespace, nvs_stats_t* outStats, nv
                                     break;
                                 }
                             }
-                            snprintf((&((*outEntryInfos)[i]))->namespace_name, NVS_KEY_NAME_MAX_SIZE, "%s",
-                                    namespace);
+                            snprintf((&((*outEntryInfos)[i]))->namespace_name, NVS_KEY_NAME_MAX_SIZE, "%s", namespace);
                             snprintf((&((*outEntryInfos)[i]))->key, NVS_KEY_NAME_MAX_SIZE, "%s", current_key);
                         }
                         i++;


### PR DESCRIPTION
### Description

<!--- What was added and/or fixed in this pull request? -->
Adds just the additional namespaced NVS functions as well as their emulator counterparts.  This PR doesn't change the usage of the existing NVS functions, which should continue to work identically.

### Test Instructions

<!--- How was this tested? -->
I've only really tested the blob and entry info functions within paint on the emulator. Assuming further testing will be done as a result of moving modes to use the functions.

### Ticket Links

<!--- Link any tickets that are completed in this pull request. -->
#52 

### Readiness Checklist
- [x] I have run `make format` to format the changes
- [x] I have compiled the firmware and the changes have no warnings
- [x] I have compiled the emulator and the changes have no warnings
- [x ] I have run `make cppcheck` and checked that `cppcheck_result.txt` has no warnings for the changes
- [x] I have added doxygen comments to any code used by more than one Swadge mode. This includes `/*! \file` comments with Design Philosophy, Usage, and Example sections for new headers.
- [x] I have run `make docs` and checked that `doxy_warnings.txt` has no warnings for the new code
