### PR TITLE
Fix settings gripes

### DIFF
--- a/components/hdw-bzr/hdw-bzr.c
+++ b/components/hdw-bzr/hdw-bzr.c
@@ -567,3 +567,42 @@ void bzrResume(void)
         }
     }
 }
+
+/**
+ * @brief Save the state of the buzzer so that it can be restored later, perhaps
+ * after playing a different sound.
+ *
+ * @return A void-pointer which can be passed back to bzrRestore()
+ */
+void* bzrSave(void)
+{
+    bzrPause();
+
+    bzrTrack_t* result = malloc(sizeof(bzrTrack_t) * NUM_BUZZERS * 2);
+    for (uint16_t bIdx = 0; bIdx < NUM_BUZZERS; bIdx++)
+    {
+        memcpy(result + bIdx * 2, &buzzers[bIdx].bgm, sizeof(bzrTrack_t));
+        memcpy(result + bIdx * 2 + 1, &buzzers[bIdx].sfx, sizeof(bzrTrack_t));
+    }
+
+    return (void*)result;
+}
+
+/**
+ * @brief Restore the state of the buzzer from a void-pointer returned by bzrSave()
+ *
+ * The data passed pointer will be freed by this call.
+ *
+ * @param data The saved state of the buzzer, returned by bzrSave()
+ */
+void bzrRestore(void* data)
+{
+    bzrTrack_t* buzzerState = (bzrTrack_t*)data;
+    for (uint16_t bIdx = 0; bIdx < NUM_BUZZERS; bIdx++)
+    {
+        memcpy(&buzzers[bIdx].bgm, buzzerState + bIdx * 2, sizeof(bzrTrack_t));
+        memcpy(&buzzers[bIdx].sfx, buzzerState + bIdx * 2 + 1, sizeof(bzrTrack_t));
+    }
+
+    free(data);
+}

--- a/components/hdw-bzr/hdw-bzr.c
+++ b/components/hdw-bzr/hdw-bzr.c
@@ -433,7 +433,7 @@ static bool IRAM_ATTR buzzer_check_next_note_isr(gptimer_handle_t timer, const g
             // Try playing SFX first
             bool sfxIsActive = buzzer_track_check_next_note(&bzr->sfx, bIdx, sfxVolume, true, tElapsedUs);
             // Then play BGM if SFX isn't active
-            bool bgmIsActive = buzzer_track_check_next_note(&bzr->bgm, bIdx, sfxVolume, !sfxIsActive, tElapsedUs);
+            bool bgmIsActive = buzzer_track_check_next_note(&bzr->bgm, bIdx, bgmVolume, !sfxIsActive, tElapsedUs);
 
             // If nothing is playing, but there is BGM (i.e. SFX finished)
             if ((false == sfxIsActive) && (false == bgmIsActive) && (NULL != bzr->bgm.sTrack))

--- a/components/hdw-bzr/hdw-bzr.c
+++ b/components/hdw-bzr/hdw-bzr.c
@@ -581,8 +581,8 @@ void* bzrSave(void)
     bzrTrack_t* result = malloc(sizeof(bzrTrack_t) * NUM_BUZZERS * 2);
     for (uint16_t bIdx = 0; bIdx < NUM_BUZZERS; bIdx++)
     {
-        memcpy(result + bIdx * 2, &buzzers[bIdx].bgm, sizeof(bzrTrack_t));
-        memcpy(result + bIdx * 2 + 1, &buzzers[bIdx].sfx, sizeof(bzrTrack_t));
+        memcpy(&result[bIdx * 2], &buzzers[bIdx].bgm, sizeof(bzrTrack_t));
+        memcpy(&result[bIdx * 2 + 1], &buzzers[bIdx].sfx, sizeof(bzrTrack_t));
     }
 
     return (void*)result;
@@ -600,8 +600,8 @@ void bzrRestore(void* data)
     bzrTrack_t* buzzerState = (bzrTrack_t*)data;
     for (uint16_t bIdx = 0; bIdx < NUM_BUZZERS; bIdx++)
     {
-        memcpy(&buzzers[bIdx].bgm, buzzerState + bIdx * 2, sizeof(bzrTrack_t));
-        memcpy(&buzzers[bIdx].sfx, buzzerState + bIdx * 2 + 1, sizeof(bzrTrack_t));
+        memcpy(&buzzers[bIdx].bgm, &buzzerState[bIdx * 2], sizeof(bzrTrack_t));
+        memcpy(&buzzers[bIdx].sfx, &buzzerState[bIdx * 2 + 1], sizeof(bzrTrack_t));
     }
 
     free(data);

--- a/components/hdw-bzr/hdw-bzr.c
+++ b/components/hdw-bzr/hdw-bzr.c
@@ -103,8 +103,8 @@ void initBuzzer(gpio_num_t bzrGpioL, ledc_timer_t ledcTimerL, ledc_channel_t led
                 ledc_timer_t ledcTimerR, ledc_channel_t ledcChannelR, uint16_t _bgmVolume, uint16_t _sfxVolume)
 {
     // Set initial volume
-    bgmVolume = _bgmVolume;
-    sfxVolume = _sfxVolume;
+    bzrSetBgmVolume(_bgmVolume);
+    bzrSetSfxVolume(_sfxVolume);
 
     // Save the LEDC timers and channels
     initSingleBuzzer(&buzzers[BZR_LEFT], bzrGpioL, ledcTimerL, ledcChannelL);

--- a/components/hdw-bzr/include/hdw-bzr.h
+++ b/components/hdw-bzr/include/hdw-bzr.h
@@ -270,5 +270,7 @@ void bzrPlayNote(noteFrequency_t freq, buzzerPlayTrack_t track, uint16_t volume)
 void bzrStopNote(buzzerPlayTrack_t track);
 void bzrPause(void);
 void bzrResume(void);
+void* bzrSave(void);
+void bzrRestore(void* data);
 
 #endif

--- a/components/hdw-led/hdw-led.c
+++ b/components/hdw-led/hdw-led.c
@@ -54,9 +54,6 @@ esp_err_t initLeds(gpio_num_t gpio, gpio_num_t gpioAlt)
 
     ESP_ERROR_CHECK(rmt_enable(led_chan));
 
-    // Set to max brightness by default
-    ledBrightness = 0;
-
     // Mirror the output to another GPIO
     // Warning, this is a hack!! led_chan is a (rmt_channel_handle_t), which is
     // really a (rmt_channel_t *), and that struct has a private definition in

--- a/components/hdw-led/hdw-led.c
+++ b/components/hdw-led/hdw-led.c
@@ -34,10 +34,13 @@ static led_t localLeds[CONFIG_NUM_LEDS + 1] = {0};
  *
  * @param gpio The GPIO the LEDs are attached to
  * @param gpioAlt A GPIO to mirror the LED output to
+ * @param brightness The brightness to start the LEDs at
  * @return ESP_OK if the LEDs initialized, or a nonzero value if they did not
  */
-esp_err_t initLeds(gpio_num_t gpio, gpio_num_t gpioAlt)
+esp_err_t initLeds(gpio_num_t gpio, gpio_num_t gpioAlt, uint8_t brightness)
 {
+    setLedBrightness(brightness);
+
     rmt_tx_channel_config_t tx_chan_config = {
         .clk_src           = RMT_CLK_SRC_DEFAULT, // select source clock
         .gpio_num          = gpio,

--- a/components/hdw-led/include/hdw-led.h
+++ b/components/hdw-led/include/hdw-led.h
@@ -65,7 +65,7 @@ typedef struct __attribute__((packed))
     uint8_t b; //!< The blue component, 0-255
 } led_t;
 
-esp_err_t initLeds(gpio_num_t gpio, gpio_num_t gpioAlt);
+esp_err_t initLeds(gpio_num_t gpio, gpio_num_t gpioAlt, uint8_t brightness);
 esp_err_t deinitLeds(void);
 esp_err_t setLeds(led_t* leds, uint8_t numLeds);
 void setLedBrightness(uint8_t brightness);

--- a/components/hdw-tft/hdw-tft.c
+++ b/components/hdw-tft/hdw-tft.c
@@ -167,7 +167,8 @@ esp_err_t setTFTBacklightBrightness(uint8_t intensity)
  * @param ledcTimer The LEDC timer to use for the PWM backlight
  */
 void initTFT(spi_host_device_t spiHost, gpio_num_t sclk, gpio_num_t mosi, gpio_num_t dc, gpio_num_t cs, gpio_num_t rst,
-             gpio_num_t backlight, bool isPwmBacklight, ledc_channel_t ledcChannel, ledc_timer_t ledcTimer, uint8_t brightness)
+             gpio_num_t backlight, bool isPwmBacklight, ledc_channel_t ledcChannel, ledc_timer_t ledcTimer,
+             uint8_t brightness)
 {
     tftSpiHost        = spiHost;
     tftBacklightPin   = backlight;

--- a/components/hdw-tft/hdw-tft.c
+++ b/components/hdw-tft/hdw-tft.c
@@ -115,7 +115,7 @@ static ledc_timer_t tftLedcTimer;
 static ledc_channel_t tftLedcChannel;
 static gpio_num_t tftBacklightPin;
 static bool tftBacklightIsPwm;
-static uint8_t tftBacklightIntensity = MAX_TFT_BRIGHTNESS;
+static uint8_t tftBacklightIntensity;
 
 static esp_lcd_panel_io_handle_t tft_io_handle = NULL;
 
@@ -261,6 +261,7 @@ void initTFT(spi_host_device_t spiHost, gpio_num_t sclk, gpio_num_t mosi, gpio_n
 #endif
 
     // Enable the backlight
+    setTFTBacklightBrightness(brightness);
     enableTFTBacklight();
 
     if (NULL == pixels)

--- a/components/hdw-tft/hdw-tft.c
+++ b/components/hdw-tft/hdw-tft.c
@@ -115,6 +115,7 @@ static ledc_timer_t tftLedcTimer;
 static ledc_channel_t tftLedcChannel;
 static gpio_num_t tftBacklightPin;
 static bool tftBacklightIsPwm;
+static uint8_t tftBacklightIntensity;
 
 static esp_lcd_panel_io_handle_t tft_io_handle = NULL;
 
@@ -132,6 +133,9 @@ static esp_lcd_panel_io_handle_t tft_io_handle = NULL;
  */
 esp_err_t setTFTBacklightBrightness(uint8_t intensity)
 {
+    // Save the value we can pass back into this function
+    tftBacklightIntensity = intensity;
+
     intensity
         = (CONFIG_TFT_MIN_BRIGHTNESS + (((CONFIG_TFT_MAX_BRIGHTNESS - CONFIG_TFT_MIN_BRIGHTNESS) * intensity) / 7));
 
@@ -163,7 +167,7 @@ esp_err_t setTFTBacklightBrightness(uint8_t intensity)
  * @param ledcTimer The LEDC timer to use for the PWM backlight
  */
 void initTFT(spi_host_device_t spiHost, gpio_num_t sclk, gpio_num_t mosi, gpio_num_t dc, gpio_num_t cs, gpio_num_t rst,
-             gpio_num_t backlight, bool isPwmBacklight, ledc_channel_t ledcChannel, ledc_timer_t ledcTimer)
+             gpio_num_t backlight, bool isPwmBacklight, ledc_channel_t ledcChannel, ledc_timer_t ledcTimer, uint8_t brightness)
 {
     tftSpiHost        = spiHost;
     tftBacklightPin   = backlight;
@@ -354,7 +358,7 @@ void enableTFTBacklight(void)
             .duty       = 255, // Disable to start.
         };
         ESP_ERROR_CHECK(ledc_channel_config(&ledc_config_backlight));
-        setTFTBacklightBrightness(CONFIG_TFT_DEFAULT_BRIGHTNESS);
+        setTFTBacklightBrightness(tftBacklightIntensity);
     }
 }
 

--- a/components/hdw-tft/hdw-tft.c
+++ b/components/hdw-tft/hdw-tft.c
@@ -165,6 +165,7 @@ esp_err_t setTFTBacklightBrightness(uint8_t intensity)
  * @param isPwmBacklight true to set up the backlight as PWM, false to have it be on/off
  * @param ledcChannel The LEDC channel to use for the PWM backlight
  * @param ledcTimer The LEDC timer to use for the PWM backlight
+ * @param brightness The initial backlight brightness
  */
 void initTFT(spi_host_device_t spiHost, gpio_num_t sclk, gpio_num_t mosi, gpio_num_t dc, gpio_num_t cs, gpio_num_t rst,
              gpio_num_t backlight, bool isPwmBacklight, ledc_channel_t ledcChannel, ledc_timer_t ledcTimer,

--- a/components/hdw-tft/hdw-tft.c
+++ b/components/hdw-tft/hdw-tft.c
@@ -115,7 +115,7 @@ static ledc_timer_t tftLedcTimer;
 static ledc_channel_t tftLedcChannel;
 static gpio_num_t tftBacklightPin;
 static bool tftBacklightIsPwm;
-static uint8_t tftBacklightIntensity;
+static uint8_t tftBacklightIntensity = MAX_TFT_BRIGHTNESS;
 
 static esp_lcd_panel_io_handle_t tft_io_handle = NULL;
 

--- a/components/hdw-tft/include/hdw-tft.h
+++ b/components/hdw-tft/include/hdw-tft.h
@@ -123,7 +123,7 @@
 typedef void (*fnBackgroundDrawCallback_t)(int16_t x, int16_t y, int16_t w, int16_t h, int16_t up, int16_t upNum);
 
 void initTFT(spi_host_device_t spiHost, gpio_num_t sclk, gpio_num_t mosi, gpio_num_t dc, gpio_num_t cs, gpio_num_t rst,
-             gpio_num_t backlight, bool isPwmBacklight, ledc_channel_t ledcChannel, ledc_timer_t ledcTimer);
+             gpio_num_t backlight, bool isPwmBacklight, ledc_channel_t ledcChannel, ledc_timer_t ledcTimer, uint8_t brightness);
 void deinitTFT(void);
 esp_err_t setTFTBacklightBrightness(uint8_t intensity);
 void disableTFTBacklight(void);

--- a/components/hdw-tft/include/hdw-tft.h
+++ b/components/hdw-tft/include/hdw-tft.h
@@ -123,7 +123,8 @@
 typedef void (*fnBackgroundDrawCallback_t)(int16_t x, int16_t y, int16_t w, int16_t h, int16_t up, int16_t upNum);
 
 void initTFT(spi_host_device_t spiHost, gpio_num_t sclk, gpio_num_t mosi, gpio_num_t dc, gpio_num_t cs, gpio_num_t rst,
-             gpio_num_t backlight, bool isPwmBacklight, ledc_channel_t ledcChannel, ledc_timer_t ledcTimer, uint8_t brightness);
+             gpio_num_t backlight, bool isPwmBacklight, ledc_channel_t ledcChannel, ledc_timer_t ledcTimer,
+             uint8_t brightness);
 void deinitTFT(void);
 esp_err_t setTFTBacklightBrightness(uint8_t intensity);
 void disableTFTBacklight(void);

--- a/emulator/src/components/hdw-bzr/hdw-bzr.c
+++ b/emulator/src/components/hdw-bzr/hdw-bzr.c
@@ -502,8 +502,8 @@ void* bzrSave(void)
     bzrTrack_t* result = malloc(sizeof(bzrTrack_t) * NUM_BUZZERS * 2);
     for (uint16_t bIdx = 0; bIdx < NUM_BUZZERS; bIdx++)
     {
-        memcpy(result + bIdx * 2, &buzzers[bIdx].bgm, sizeof(bzrTrack_t));
-        memcpy(result + bIdx * 2 + 1, &buzzers[bIdx].sfx, sizeof(bzrTrack_t));
+        memcpy(&result[bIdx * 2], &buzzers[bIdx].bgm, sizeof(bzrTrack_t));
+        memcpy(&result[bIdx * 2 + 1], &buzzers[bIdx].sfx, sizeof(bzrTrack_t));
     }
 
     return (void*)result;
@@ -521,8 +521,8 @@ void bzrRestore(void* data)
     bzrTrack_t* buzzerState = (bzrTrack_t*)data;
     for (uint16_t bIdx = 0; bIdx < NUM_BUZZERS; bIdx++)
     {
-        memcpy(&buzzers[bIdx].bgm, buzzerState + bIdx * 2, sizeof(bzrTrack_t));
-        memcpy(&buzzers[bIdx].sfx, buzzerState + bIdx * 2 + 1, sizeof(bzrTrack_t));
+        memcpy(&buzzers[bIdx].bgm, &buzzerState[bIdx * 2], sizeof(bzrTrack_t));
+        memcpy(&buzzers[bIdx].sfx, &buzzerState[bIdx * 2 + 1], sizeof(bzrTrack_t));
     }
 
     free(data);

--- a/emulator/src/components/hdw-bzr/hdw-bzr.c
+++ b/emulator/src/components/hdw-bzr/hdw-bzr.c
@@ -488,3 +488,42 @@ void bzrResume(void)
         }
     }
 }
+
+/**
+ * @brief Save the state of the buzzer so that it can be restored later, perhaps
+ * after playing a different sound.
+ *
+ * @return A void-pointer which can be passed back to bzrRestore()
+ */
+void* bzrSave(void)
+{
+    bzrPause();
+
+    bzrTrack_t* result = malloc(sizeof(bzrTrack_t) * NUM_BUZZERS * 2);
+    for (uint16_t bIdx = 0; bIdx < NUM_BUZZERS; bIdx++)
+    {
+        memcpy(result + bIdx * 2, &buzzers[bIdx].bgm, sizeof(bzrTrack_t));
+        memcpy(result + bIdx * 2 + 1, &buzzers[bIdx].sfx, sizeof(bzrTrack_t));
+    }
+
+    return (void*)result;
+}
+
+/**
+ * @brief Restore the state of the buzzer from a void-pointer returned by bzrSave()
+ *
+ * The data passed pointer will be freed by this call.
+ *
+ * @param data The saved state of the buzzer, returned by bzrSave()
+ */
+void bzrRestore(void* data)
+{
+    bzrTrack_t* buzzerState = (bzrTrack_t*)data;
+    for (uint16_t bIdx = 0; bIdx < NUM_BUZZERS; bIdx++)
+    {
+        memcpy(&buzzers[bIdx].bgm, buzzerState + bIdx * 2, sizeof(bzrTrack_t));
+        memcpy(&buzzers[bIdx].sfx, buzzerState + bIdx * 2 + 1, sizeof(bzrTrack_t));
+    }
+
+    free(data);
+}

--- a/emulator/src/components/hdw-bzr/hdw-bzr.c
+++ b/emulator/src/components/hdw-bzr/hdw-bzr.c
@@ -102,8 +102,8 @@ void initBuzzer(gpio_num_t bzrGpioL, ledc_timer_t ledcTimerL, ledc_channel_t led
     }
 
     memset(&buzzers, 0, sizeof(buzzers));
-    bgmVolume = _bgmVolume;
-    sfxVolume = _sfxVolume;
+    bzrSetBgmVolume(_bgmVolume);
+    bzrSetSfxVolume(_sfxVolume);
 
     const esp_timer_create_args_t checkNoteTimeArgs = {
         .arg                   = NULL,

--- a/emulator/src/components/hdw-led/hdw-led.c
+++ b/emulator/src/components/hdw-led/hdw-led.c
@@ -25,10 +25,10 @@ static uint8_t ledBrightness         = 0;
  * @param gpioAlt The GPIO to mirror the LEDs to
  * @return ESP_OK if the LEDs initialized, or a nonzero value if they did not
  */
-esp_err_t initLeds(gpio_num_t gpio, gpio_num_t gpioAlt)
+esp_err_t initLeds(gpio_num_t gpio, gpio_num_t gpioAlt, uint8_t brightness)
 {
     memset(rdLeds, 0, sizeof(rdLeds));
-    ledBrightness = 0;
+    setLedBrightness(brightness);
     return ESP_OK;
 }
 

--- a/emulator/src/components/hdw-tft/hdw-tft.c
+++ b/emulator/src/components/hdw-tft/hdw-tft.c
@@ -69,6 +69,7 @@ static uint8_t tftBrightness         = CONFIG_TFT_MAX_BRIGHTNESS;
  * @param isPwmBacklight true to set up the backlight as PWM, false to have it be on/off
  * @param ledcChannel The LEDC channel to use for the PWM backlight
  * @param ledcTimer The LEDC timer to use for the PWM backlight
+ * @param brightness The initial backlight brightness
  */
 void initTFT(spi_host_device_t spiHost, gpio_num_t sclk, gpio_num_t mosi, gpio_num_t dc, gpio_num_t cs, gpio_num_t rst,
              gpio_num_t backlight, bool isPwmBacklight, ledc_channel_t ledcChannel, ledc_timer_t ledcTimer,

--- a/emulator/src/components/hdw-tft/hdw-tft.c
+++ b/emulator/src/components/hdw-tft/hdw-tft.c
@@ -71,7 +71,8 @@ static uint8_t tftBrightness         = CONFIG_TFT_MAX_BRIGHTNESS;
  * @param ledcTimer The LEDC timer to use for the PWM backlight
  */
 void initTFT(spi_host_device_t spiHost, gpio_num_t sclk, gpio_num_t mosi, gpio_num_t dc, gpio_num_t cs, gpio_num_t rst,
-             gpio_num_t backlight, bool isPwmBacklight, ledc_channel_t ledcChannel, ledc_timer_t ledcTimer, uint8_t brightness)
+             gpio_num_t backlight, bool isPwmBacklight, ledc_channel_t ledcChannel, ledc_timer_t ledcTimer,
+             uint8_t brightness)
 {
     // ARGB pixels
     bitmapWidth  = TFT_WIDTH;
@@ -229,7 +230,7 @@ void drawDisplayTft(fnBackgroundDrawCallback_t fnBackgroundDrawCallback)
 
                     uint32_t color = paletteColorsEmu[frameBuffer[(y * TFT_WIDTH) + x]];
 
-                    uint8_t a = (color) & 0xFF;
+                    uint8_t a = (color)&0xFF;
                     uint8_t r = (color >> 8) & 0xFF;
                     r         = (r * tftBrightness) / CONFIG_TFT_MAX_BRIGHTNESS;
                     uint8_t g = (color >> 16) & 0xFF;

--- a/emulator/src/components/hdw-tft/hdw-tft.c
+++ b/emulator/src/components/hdw-tft/hdw-tft.c
@@ -71,7 +71,7 @@ static uint8_t tftBrightness         = CONFIG_TFT_MAX_BRIGHTNESS;
  * @param ledcTimer The LEDC timer to use for the PWM backlight
  */
 void initTFT(spi_host_device_t spiHost, gpio_num_t sclk, gpio_num_t mosi, gpio_num_t dc, gpio_num_t cs, gpio_num_t rst,
-             gpio_num_t backlight, bool isPwmBacklight, ledc_channel_t ledcChannel, ledc_timer_t ledcTimer)
+             gpio_num_t backlight, bool isPwmBacklight, ledc_channel_t ledcChannel, ledc_timer_t ledcTimer, uint8_t brightness)
 {
     // ARGB pixels
     bitmapWidth  = TFT_WIDTH;
@@ -89,6 +89,8 @@ void initTFT(spi_host_device_t spiHost, gpio_num_t sclk, gpio_num_t mosi, gpio_n
         displayMult         = 1;
         scaledBitmapDisplay = calloc(TFT_WIDTH * TFT_HEIGHT, sizeof(uint32_t));
     }
+
+    setTFTBacklightBrightness(brightness);
 }
 
 /**

--- a/emulator/src/emu_main.c
+++ b/emulator/src/emu_main.c
@@ -145,8 +145,8 @@ int main(int argc, char** argv)
         calculatePaneMinimums(paneMins);
         int32_t sidePanesW      = paneMins[PANE_LEFT].min + paneMins[PANE_RIGHT].min;
         int32_t topBottomPanesH = paneMins[PANE_TOP].min + paneMins[PANE_BOTTOM].min;
-        int32_t winW            = (TFT_WIDTH) * 2 + sidePanesW;
-        int32_t winH            = (TFT_HEIGHT) * 2 + topBottomPanesH;
+        int32_t winW            = (TFT_WIDTH)*2 + sidePanesW;
+        int32_t winH            = (TFT_HEIGHT)*2 + topBottomPanesH;
 
         if (emulatorArgs.headless)
         {

--- a/main/modes/mainMenu/mainMenu.c
+++ b/main/modes/mainMenu/mainMenu.c
@@ -38,6 +38,8 @@ typedef struct
     menuLogbookRenderer_t* renderer;
     font_t logbook;
     song_t jingle;
+    int32_t lastBgmVol;
+    int32_t lastSfxVol;
 } mainMenu_t;
 
 //==============================================================================
@@ -159,6 +161,10 @@ static void mainMenuEnterMode(void)
     addSettingsItemToMenu(mainMenu->menu, sfxVolSettingLabel, getSfxVolumeSettingBounds(), getSfxVolumeSetting());
     addSettingsItemToMenu(mainMenu->menu, micSettingLabel, getMicGainSettingBounds(), getMicGainSetting());
 
+    // These are just used for playing the sound only when the setting changes
+    mainMenu->lastBgmVol = getBgmVolumeSetting();
+    mainMenu->lastSfxVol = getSfxVolumeSetting();
+
     addSettingsOptionsItemToMenu(mainMenu->menu, screenSaverSettingsLabel, screenSaverSettingsOptions,
                                  screenSaverSettingsValues, ARRAY_SIZE(screenSaverSettingsValues),
                                  getScreensaverTimeSettingBounds(), getScreensaverTimeSetting());
@@ -219,6 +225,8 @@ static void mainMenuCb(const char* label, bool selected, uint32_t settingVal)
 {
     // Stop the buzzer first no matter what, so that it turns off
     // if we scroll away from the BGM or SFX settings.
+
+    // Always stop the buzzer unless we're on one of the SFX settings
     bzrStop(true);
 
     if (selected)
@@ -310,13 +318,21 @@ static void mainMenuCb(const char* label, bool selected, uint32_t settingVal)
         }
         else if (bgmVolSettingLabel == label)
         {
-            setBgmVolumeSetting(settingVal);
-            bzrPlayBgm(&mainMenu->jingle, BZR_STEREO);
+            if (settingVal != mainMenu->lastBgmVol)
+            {
+                mainMenu->lastBgmVol = settingVal;
+                setBgmVolumeSetting(settingVal);
+                bzrPlayBgm(&mainMenu->jingle, BZR_STEREO);
+            }
         }
         else if (sfxVolSettingLabel == label)
         {
-            setSfxVolumeSetting(settingVal);
-            bzrPlaySfx(&mainMenu->jingle, BZR_STEREO);
+            if (settingVal != mainMenu->lastSfxVol)
+            {
+                mainMenu->lastSfxVol = settingVal;
+                setSfxVolumeSetting(settingVal);
+                bzrPlaySfx(&mainMenu->jingle, BZR_STEREO);
+            }
         }
         else if (micSettingLabel == label)
         {

--- a/main/modes/quickSettings/quickSettings.c
+++ b/main/modes/quickSettings/quickSettings.c
@@ -490,21 +490,26 @@ static int32_t quickSettingsMenuFlipItem(const char* label)
 
 static void quickSettingsSetLeds(int64_t elapsedUs)
 {
-    int64_t period = 3600000; // 3.6s
+    int64_t period  = 3600000; // 3.6s
     int64_t rOffset = (period * 2 / 3);
     int64_t gOffset = (period * 1 / 3);
     int64_t bOffset = 0;
     uint8_t rSpeed = 1, gSpeed = 1, bSpeed = 2;
-
 
     quickSettings->ledTimer = (quickSettings->ledTimer + elapsedUs) % period;
 
     led_t leds[CONFIG_NUM_LEDS];
     for (uint8_t i = 0; i < CONFIG_NUM_LEDS; i++)
     {
-        leds[i].r = MAX(0, getSin1024((quickSettings->ledTimer * rSpeed + rOffset + i * period / CONFIG_NUM_LEDS) % period * 360 / period)) * 255 / 1024;
-        leds[i].g = MAX(0, getSin1024((quickSettings->ledTimer * gSpeed + gOffset + i * period / CONFIG_NUM_LEDS) % period * 360 / period)) * 255 / 1024;
-        leds[i].b = MAX(0, getSin1024((quickSettings->ledTimer * bSpeed + bOffset + i * period / CONFIG_NUM_LEDS) % period * 360 / period)) * 255 / 1024;
+        leds[i].r = MAX(0, getSin1024((quickSettings->ledTimer * rSpeed + rOffset + i * period / CONFIG_NUM_LEDS)
+                                      % period * 360 / period))
+                    * 255 / 1024;
+        leds[i].g = MAX(0, getSin1024((quickSettings->ledTimer * gSpeed + gOffset + i * period / CONFIG_NUM_LEDS)
+                                      % period * 360 / period))
+                    * 255 / 1024;
+        leds[i].b = MAX(0, getSin1024((quickSettings->ledTimer * bSpeed + bOffset + i * period / CONFIG_NUM_LEDS)
+                                      % period * 360 / period))
+                    * 255 / 1024;
     }
 
     setLeds(leds, ARRAY_SIZE(leds));

--- a/main/modes/quickSettings/quickSettings.c
+++ b/main/modes/quickSettings/quickSettings.c
@@ -40,6 +40,7 @@ typedef struct
     menuQuickSettingsRenderer_t* renderer; ///< Renderer for the menu
     font_t font;                           ///< The font used for menu text
     int64_t ledTimer;
+    bool showLeds;
     song_t jingle;
     void* buzzerState;
 
@@ -216,6 +217,7 @@ static void quickSettingsEnterMode(void)
 
     quickSettings->prevSfxValue = sfxValue;
     quickSettings->prevBgmValue = bgmValue;
+    quickSettings->showLeds = true;
 
     // Add the actual items to the menu
     addSettingsItemToMenu(quickSettings->menu, quickSettingsLeds, ledsBounds, ledsValue);
@@ -342,7 +344,15 @@ static void quickSettingsMainLoop(int64_t elapsedUs)
         drawMenuQuickSettings(quickSettings->menu, quickSettings->renderer, elapsedUs);
 
         // Update the LEDs
-        quickSettingsSetLeds(elapsedUs);
+        if (quickSettings->showLeds)
+        {
+            quickSettingsSetLeds(elapsedUs);
+        }
+        else
+        {
+            led_t leds[CONFIG_NUM_LEDS] = {0};
+            setLeds(leds, ARRAY_SIZE(leds));
+        }
     }
 }
 
@@ -386,6 +396,8 @@ static int32_t quickSettingsFlipValue(const char* label, int32_t value)
  */
 static void quickSettingsOnChange(const char* label, int32_t value)
 {
+    quickSettings->showLeds = false;
+
     if (label == quickSettingsLeds)
     {
         bzrStop(true);
@@ -394,6 +406,8 @@ static void quickSettingsOnChange(const char* label, int32_t value)
         {
             quickSettings->lastOnLedsValue = value;
         }
+
+        quickSettings->showLeds = true;
     }
     else if (label == quickSettingsBacklight)
     {

--- a/main/swadge2024.c
+++ b/main/swadge2024.c
@@ -290,7 +290,8 @@ void app_main(void)
             GPIO_NUM_35,    // backlight
             true,           // PWM backlight
             LEDC_CHANNEL_2, // Channel to use for PWM backlight
-            LEDC_TIMER_2);  // Timer to use for PWM backlight
+            LEDC_TIMER_2,   // Timer to use for PWM backlight
+            getTftBrightnessSetting()); // TFT Brightness
 
     // Initialize the RGB LEDs
     initLeds(GPIO_NUM_39, GPIO_NUM_18);

--- a/main/swadge2024.c
+++ b/main/swadge2024.c
@@ -282,15 +282,15 @@ void app_main(void)
 
     // Init TFT, use a different LEDC channel than buzzer
     initTFT(SPI2_HOST,
-            GPIO_NUM_36,    // sclk
-            GPIO_NUM_37,    // mosi
-            GPIO_NUM_21,    // dc
-            GPIO_NUM_34,    // cs
-            GPIO_NUM_38,    // rst
-            GPIO_NUM_35,    // backlight
-            true,           // PWM backlight
-            LEDC_CHANNEL_2, // Channel to use for PWM backlight
-            LEDC_TIMER_2,   // Timer to use for PWM backlight
+            GPIO_NUM_36,                // sclk
+            GPIO_NUM_37,                // mosi
+            GPIO_NUM_21,                // dc
+            GPIO_NUM_34,                // cs
+            GPIO_NUM_38,                // rst
+            GPIO_NUM_35,                // backlight
+            true,                       // PWM backlight
+            LEDC_CHANNEL_2,             // Channel to use for PWM backlight
+            LEDC_TIMER_2,               // Timer to use for PWM backlight
             getTftBrightnessSetting()); // TFT Brightness
 
     // Initialize the RGB LEDs

--- a/main/swadge2024.c
+++ b/main/swadge2024.c
@@ -267,7 +267,7 @@ void app_main(void)
 
     // Init buzzer. This must be called before initMic()
     initBuzzer(GPIO_NUM_40, LEDC_TIMER_0, LEDC_CHANNEL_0, //
-               GPIO_NUM_42, LEDC_TIMER_1, LEDC_CHANNEL_1, false, false);
+               GPIO_NUM_42, LEDC_TIMER_1, LEDC_CHANNEL_1, getBgmVolumeSetting(), getSfxVolumeSetting());
 
     // Init mic if it is used by the mode
     if (NULL != cSwadgeMode->fnAudioCallback)
@@ -294,7 +294,7 @@ void app_main(void)
             getTftBrightnessSetting()); // TFT Brightness
 
     // Initialize the RGB LEDs
-    initLeds(GPIO_NUM_39, GPIO_NUM_18);
+    initLeds(GPIO_NUM_39, GPIO_NUM_18, getLedBrightnessSetting());
 
     // Init esp-now if requested by the mode
     if ((ESP_NOW == cSwadgeMode->wifiMode) || (ESP_NOW_IMMEDIATE == cSwadgeMode->wifiMode))

--- a/main/utils/settingsManager.c
+++ b/main/utils/settingsManager.c
@@ -140,19 +140,15 @@ void readAllSettings(void)
     // Read the test mode setting
     readSetting(&test_setting);
 
-    // Read and set buzzer settings
+    // Read the buzzer settings
     readSetting(&bgm_setting);
-    bzrSetBgmVolume(getBgmVolumeSetting());
     readSetting(&sfx_setting);
-    bzrSetSfxVolume(getSfxVolumeSetting());
 
-    // Read and apply TFT settings
+    // Read the TFT settings
     readSetting(&tft_br_setting);
-    setTFTBacklightBrightness(getTftBrightnessSetting());
 
-    // Read and apply LED settings
+    // Read the LED settings
     readSetting(&led_br_setting);
-    setLedBrightness(getLedBrightnessSetting());
 
     // Read the mic setting
     readSetting(&mic_setting);


### PR DESCRIPTION
### Description

Fixes a couple settings-related issues I noticed while working on real hardware, and adds a bit more polish to quick and regular settings.

Fixed issues:
* TFT and LED brightness settings didn't actually apply until you changed them after boot, since they initialize after reading the settings and would only use defaults.
* BGM was played with SFX volume on hardware

Enhancements:
* Quick settings menu now does an LED pattern while setting LED brightness
* Added feature to save and restore the buzzer state, so quick settings doesn't reset the underlying mode's music
* Quick settings menu plays sound while changing volume (does not work, at all -- seems to be an issue with quick settings specifically, or I am doing something dumb)
* Main menu settings only play sounds when levels are changed, not just scrolling past them

### Test Instructions

On the real swadge, change the TFT and LED brightness settings however you want, then reboot the swadge. You should see that the settings are set properly from the beginning, instead of using the defaults until you change them.

Go into the main menu settings and scroll past the SFX/BGM settings. Note that they don't play sound until you actually change the value.

### Ticket Links

<!--- Link any tickets that are completed in this pull request. -->

### Readiness Checklist
- [x] I have run `make format` to format the changes
- [x] I have compiled the firmware and the changes have no warnings
- [x] I have compiled the emulator and the changes have no warnings
- [x] I have run `make cppcheck` and checked that `cppcheck_result.txt` has no warnings for the changes
- [x] I have added doxygen comments to any code used by more than one Swadge mode. This includes `/*! \file` comments with Design Philosophy, Usage, and Example sections for new headers.
- [x] I have run `make docs` and checked that `doxy_warnings.txt` has no warnings for the new code
