### PR TITLE
Reorganize IMU and quaternion math functions

### DIFF
--- a/components/hdw-imu/CMakeLists.txt
+++ b/components/hdw-imu/CMakeLists.txt
@@ -1,4 +1,4 @@
-idf_component_register(SRCS "hdw-imu.c"
+idf_component_register(SRCS "hdw-imu.c" "quaternions.c"
                     INCLUDE_DIRS "include" "."
                     REQUIRES driver
 					PRIV_REQUIRES hdw-nvs)

--- a/components/hdw-imu/hdw-imu.c
+++ b/components/hdw-imu/hdw-imu.c
@@ -12,6 +12,7 @@
 #include "rom/gpio.h"
 #include "soc/gpio_struct.h"
 #include "hdw-nvs.h"
+#include "quaternions.h"
 
 #define DSCL_OUTPUT                             \
     {                                           \
@@ -94,7 +95,7 @@ typedef enum __attribute__((packed))
 LSM6DSLData LSM6DSL;
 
 //==============================================================================
-// Utility Prototypes
+// Static Function Prototypes
 //==============================================================================
 
 float rsqrtf(float x);
@@ -107,182 +108,14 @@ void mathRotateVectorByInverseOfQuaternion(float* pout, const float* q, const fl
 void mathRotateVectorByQuaternion(float* pout, const float* q, const float* p);
 
 static inline uint32_t getCycleCount();
-
-esp_err_t GeneralSet(int dev, int reg, int val);
-esp_err_t LSM6DSLSet(int reg, int val);
-int GeneralI2CGet(int device, int reg, uint8_t* data, int data_len);
-int ReadLSM6DSL(uint8_t* data, int data_len);
+static esp_err_t GeneralSet(int dev, int reg, int val);
+static esp_err_t LSM6DSLSet(int reg, int val);
+static int GeneralI2CGet(int device, int reg, uint8_t* data, int data_len);
+static int ReadLSM6DSL(uint8_t* data, int data_len);
 
 //==============================================================================
 // Utility Functions
 //==============================================================================
-
-/**
- * @brief Perform a fast, approximate reciprocal square root
- *
- * @param x The number to take a recriprocal square root of.
- * @return approximately 1/sqrt(x)
- */
-float rsqrtf(float x)
-{
-    typedef union
-    {
-        int32_t i;
-        float f;
-    } fiunion;
-    const float xhalf = 0.5f * x;
-    fiunion i         = {.f = x};
-    i.i               = 0x5f375a86 - (i.i >> 1);
-    x                 = i.f;
-    x                 = x * (1.5f - xhalf * x * x);
-    x                 = x * (1.5f - xhalf * x * x);
-    return x;
-}
-
-/**
- * @brief Perform a fast, approximate square root
- *
- * @param x The number to take a square root of.
- * @return approximately sqrt(x) (but is much faster)
- */
-float mathsqrtf(float x)
-{
-    // Trick to do approximate, fast square roots. (Though it is surprisingly fast)
-    int sign = x < 0;
-    if (sign)
-        x = -x;
-    if (x < 0.0000001)
-        return 0.0001;
-    float o = x;
-    o       = (o + x / o) / 2;
-    o       = (o + x / o) / 2;
-    o       = (o + x / o) / 2;
-    o       = (o + x / o) / 2;
-    if (sign)
-        return -o;
-    else
-        return o;
-}
-
-/**
- * @brief convert euler angles (in radians) to a quaternion.
- *
- * @param q Pointer to the wxyz quat (float[4]) to be written.
- * @param euler Pointer to a float[3] of euler angles.
- */
-void mathEulerToQuat(float* q, const float* euler)
-{
-    float pitch = euler[0];
-    float yaw   = euler[1];
-    float roll  = euler[2];
-    float cr    = cosf(pitch * 0.5);
-    float sr    = sinf(pitch * 0.5); // Pitch: About X
-    float cp    = cosf(yaw * 0.5);
-    float sp    = sinf(yaw * 0.5); // Yaw:   About Y
-    float cy    = cosf(roll * 0.5);
-    float sy    = sinf(roll * 0.5); // Roll:  About Z
-    q[0]        = cr * cp * cy + sr * sp * sy;
-    q[1]        = sr * cp * cy - cr * sp * sy;
-    q[2]        = cr * sp * cy + sr * cp * sy;
-    q[3]        = cr * cp * sy - sr * sp * cy;
-}
-
-/**
- * @brief Rotate one quaternion by another (and do not normalize)
- *
- * @param qout Pointer to the wxyz quat (float[4]) to be written.
- * @param q1 First quaternion to be rotated.
- * @param q2 Quaternion to rotate q1 by.
- */
-void mathQuatApply(float* qout, const float* q1, const float* q2)
-{
-    // NOTE: Does not normalize - you will need to normalize eventually.
-    float tmpw, tmpx, tmpy;
-    tmpw    = (q1[0] * q2[0]) - (q1[1] * q2[1]) - (q1[2] * q2[2]) - (q1[3] * q2[3]);
-    tmpx    = (q1[0] * q2[1]) + (q1[1] * q2[0]) + (q1[2] * q2[3]) - (q1[3] * q2[2]);
-    tmpy    = (q1[0] * q2[2]) - (q1[1] * q2[3]) + (q1[2] * q2[0]) + (q1[3] * q2[1]);
-    qout[3] = (q1[0] * q2[3]) + (q1[1] * q2[2]) - (q1[2] * q2[1]) + (q1[3] * q2[0]);
-    qout[2] = tmpy;
-    qout[1] = tmpx;
-    qout[0] = tmpw;
-}
-
-/**
- * @brief Normalize a quaternion
- *
- * @param qout Pointer to the wxyz quat (float[4]) to be written.
- * @param qin Pointer to the quaterion to normalize.
- */
-void mathQuatNormalize(float* qout, const float* qin)
-{
-    float qmag = qin[0] * qin[0] + qin[1] * qin[1] + qin[2] * qin[2] + qin[3] * qin[3];
-    qmag       = rsqrtf(qmag);
-    qout[0]    = qin[0] * qmag;
-    qout[1]    = qin[1] * qmag;
-    qout[2]    = qin[2] * qmag;
-    qout[3]    = qin[3] * qmag;
-}
-
-/**
- * @brief Perform a 3D cross product
- *
- * @param p Pointer to the float[3] output of the cross product (p = a x b)
- * @param a Pointer to the float[3] of the cross product a vector.
- * @param b Pointer to the float[3] of the cross product b vector.
- */
-void mathCrossProduct(float* p, const float* a, const float* b)
-{
-    float tx = a[1] * b[2] - a[2] * b[1];
-    float ty = a[2] * b[0] - a[0] * b[2];
-    p[2]     = a[0] * b[1] - a[1] * b[0];
-    p[1]     = ty;
-    p[0]     = tx;
-}
-
-/**
- * @brief Rotate a 3D vector by a quaternion
- *
- * @param pout Pointer to the float[3] output of the rotation
- * @param q Pointer to the wxyz quaternion (float[4]) of the rotation.
- * @param p Pointer to the float[3] of the vector to rotates.
- */
-void mathRotateVectorByQuaternion(float* pout, const float* q, const float* p)
-{
-    // return v + 2.0 * cross(q.xyz, cross(q.xyz, v) + q.w * v);
-    float iqo[3];
-    mathCrossProduct(iqo, q + 1 /*.xyz*/, p);
-    iqo[0] += q[0] * p[0];
-    iqo[1] += q[0] * p[1];
-    iqo[2] += q[0] * p[2];
-    float ret[3];
-    mathCrossProduct(ret, q + 1 /*.xyz*/, iqo);
-    pout[0] = ret[0] * 2.0 + p[0];
-    pout[1] = ret[1] * 2.0 + p[1];
-    pout[2] = ret[2] * 2.0 + p[2];
-}
-
-/**
- * @brief Rotate a 3D vector by the inverse of a quaternion
- *
- * @param pout Pointer to the float[3] output of the antirotation.
- * @param q Pointer to the wxyz quaternion (float[4]) opposite of the rotation.
- * @param p Pointer to the float[3] of the vector to antirotates.
- */
-void mathRotateVectorByInverseOfQuaternion(float* pout, const float* q, const float* p)
-{
-    // General note: Performing a transform this way can be about 20-30% slower than a well formed 3x3 matrix.
-    // return v + 2.0 * cross(q.xyz, cross(q.xyz, v) + q.w * v);
-    float iqo[3];
-    mathCrossProduct(iqo, p, q + 1 /*.xyz*/);
-    iqo[0] += q[0] * p[0];
-    iqo[1] += q[0] * p[1];
-    iqo[2] += q[0] * p[2];
-    float ret[3];
-    mathCrossProduct(ret, iqo, q + 1 /*.xyz*/);
-    pout[0] = ret[0] * 2.0 + p[0];
-    pout[1] = ret[1] * 2.0 + p[1];
-    pout[2] = ret[2] * 2.0 + p[2];
-}
 
 static inline uint32_t getCycleCount()
 {
@@ -303,7 +136,7 @@ static inline uint32_t getCycleCount()
  * @param val The 8-bit value to set the register to.
  * @return ESP_OK if the operation was successful.
  */
-esp_err_t GeneralSet(int dev, int reg, int val)
+static esp_err_t GeneralSet(int dev, int reg, int val)
 {
     SendStart();
     SendByte(dev << 1);
@@ -320,7 +153,7 @@ esp_err_t GeneralSet(int dev, int reg, int val)
  * @param val The 8-bit value to set the register to.
  * @return ESP_OK if the operation was successful.
  */
-esp_err_t LSM6DSLSet(int reg, int val)
+static esp_err_t LSM6DSLSet(int reg, int val)
 {
     return GeneralSet(LSM6DSL_ADDRESS, reg, val);
 }
@@ -334,7 +167,7 @@ esp_err_t LSM6DSLSet(int reg, int val)
  * @param data_len Number of bytes to read.
  * @return positive number if operation was successful, or esp_err_t if failure.
  */
-int GeneralI2CGet(int device, int reg, uint8_t* data, int data_len)
+static int GeneralI2CGet(int device, int reg, uint8_t* data, int data_len)
 {
     SendStart();
     SendByte(device << 1);
@@ -357,7 +190,7 @@ int GeneralI2CGet(int device, int reg, uint8_t* data, int data_len)
  * @param data_len The maximum size (in words) to read.
  * @return positive number if operation was successful, or esp_err_t if failure.
  */
-int ReadLSM6DSL(uint8_t* data, int data_len)
+static int ReadLSM6DSL(uint8_t* data, int data_len)
 {
     uint32_t fifolen = 0;
     SendStart();

--- a/components/hdw-imu/include/hdw-imu.h
+++ b/components/hdw-imu/include/hdw-imu.h
@@ -46,6 +46,8 @@
 #include <hal/gpio_types.h>
 #include <esp_err.h>
 
+#include "quaternions.h"
+
 typedef struct
 {
     int32_t temp;
@@ -88,20 +90,5 @@ esp_err_t accelIntegrate(void);
 esp_err_t accelPerformCal(void);
 float accelGetStdDevInCal(void);
 void accelSetRegistersAndReset(void);
-
-// Utility functions (to replace at a later time)
-
-float rsqrtf(float x);
-float mathsqrtf(float x);
-void mathEulerToQuat(float* q, const float* euler);
-void mathQuatApply(float* qout, const float* q1, const float* q2);
-void mathQuatNormalize(float* qout, const float* qin);
-void mathCrossProduct(float* p, const float* a, const float* b);
-void mathRotateVectorByInverseOfQuaternion(float* pout, const float* q, const float* p);
-void mathRotateVectorByQuaternion(float* pout, const float* q, const float* p);
-esp_err_t GeneralSet(int dev, int reg, int val);
-esp_err_t LSM6DSLSet(int reg, int val);
-int GeneralI2CGet(int device, int reg, uint8_t* data, int data_len);
-int ReadLSM6DSL(uint8_t* data, int data_len);
 
 #endif

--- a/components/hdw-imu/include/quaternions.h
+++ b/components/hdw-imu/include/quaternions.h
@@ -1,0 +1,17 @@
+#ifndef _QUATERNIONS_H_
+#define _QUATERNIONS_H_
+
+#include <float.h>
+#include <stddef.h>
+#include <stdint.h>
+
+float rsqrtf(float x);
+float mathsqrtf(float x);
+void mathEulerToQuat(float* q, const float* euler);
+void mathQuatApply(float* qout, const float* q1, const float* q2);
+void mathQuatNormalize(float* qout, const float* qin);
+void mathCrossProduct(float* p, const float* a, const float* b);
+void mathRotateVectorByInverseOfQuaternion(float* pout, const float* q, const float* p);
+void mathRotateVectorByQuaternion(float* pout, const float* q, const float* p);
+
+#endif

--- a/components/hdw-imu/quaternions.c
+++ b/components/hdw-imu/quaternions.c
@@ -1,0 +1,170 @@
+#include "quaternions.h"
+
+#include <math.h>
+
+/**
+ * @brief Perform a fast, approximate reciprocal square root
+ *
+ * @param x The number to take a recriprocal square root of.
+ * @return approximately 1/sqrt(x)
+ */
+float rsqrtf(float x)
+{
+    typedef union
+    {
+        int32_t i;
+        float f;
+    } fiunion;
+    const float xhalf = 0.5f * x;
+    fiunion i         = {.f = x};
+    i.i               = 0x5f375a86 - (i.i >> 1);
+    x                 = i.f;
+    x                 = x * (1.5f - xhalf * x * x);
+    x                 = x * (1.5f - xhalf * x * x);
+    return x;
+}
+
+/**
+ * @brief Perform a fast, approximate square root
+ *
+ * @param x The number to take a square root of.
+ * @return approximately sqrt(x) (but is much faster)
+ */
+float mathsqrtf(float x)
+{
+    // Trick to do approximate, fast square roots. (Though it is surprisingly fast)
+    int sign = x < 0;
+    if (sign)
+        x = -x;
+    if (x < 0.0000001)
+        return 0.0001;
+    float o = x;
+    o       = (o + x / o) / 2;
+    o       = (o + x / o) / 2;
+    o       = (o + x / o) / 2;
+    o       = (o + x / o) / 2;
+    if (sign)
+        return -o;
+    else
+        return o;
+}
+
+/**
+ * @brief convert euler angles (in radians) to a quaternion.
+ *
+ * @param q Pointer to the wxyz quat (float[4]) to be written.
+ * @param euler Pointer to a float[3] of euler angles.
+ */
+void mathEulerToQuat(float* q, const float* euler)
+{
+    float pitch = euler[0];
+    float yaw   = euler[1];
+    float roll  = euler[2];
+    float cr    = cosf(pitch * 0.5);
+    float sr    = sinf(pitch * 0.5); // Pitch: About X
+    float cp    = cosf(yaw * 0.5);
+    float sp    = sinf(yaw * 0.5); // Yaw:   About Y
+    float cy    = cosf(roll * 0.5);
+    float sy    = sinf(roll * 0.5); // Roll:  About Z
+    q[0]        = cr * cp * cy + sr * sp * sy;
+    q[1]        = sr * cp * cy - cr * sp * sy;
+    q[2]        = cr * sp * cy + sr * cp * sy;
+    q[3]        = cr * cp * sy - sr * sp * cy;
+}
+
+/**
+ * @brief Rotate one quaternion by another (and do not normalize)
+ *
+ * @param qout Pointer to the wxyz quat (float[4]) to be written.
+ * @param q1 First quaternion to be rotated.
+ * @param q2 Quaternion to rotate q1 by.
+ */
+void mathQuatApply(float* qout, const float* q1, const float* q2)
+{
+    // NOTE: Does not normalize - you will need to normalize eventually.
+    float tmpw, tmpx, tmpy;
+    tmpw    = (q1[0] * q2[0]) - (q1[1] * q2[1]) - (q1[2] * q2[2]) - (q1[3] * q2[3]);
+    tmpx    = (q1[0] * q2[1]) + (q1[1] * q2[0]) + (q1[2] * q2[3]) - (q1[3] * q2[2]);
+    tmpy    = (q1[0] * q2[2]) - (q1[1] * q2[3]) + (q1[2] * q2[0]) + (q1[3] * q2[1]);
+    qout[3] = (q1[0] * q2[3]) + (q1[1] * q2[2]) - (q1[2] * q2[1]) + (q1[3] * q2[0]);
+    qout[2] = tmpy;
+    qout[1] = tmpx;
+    qout[0] = tmpw;
+}
+
+/**
+ * @brief Normalize a quaternion
+ *
+ * @param qout Pointer to the wxyz quat (float[4]) to be written.
+ * @param qin Pointer to the quaterion to normalize.
+ */
+void mathQuatNormalize(float* qout, const float* qin)
+{
+    float qmag = qin[0] * qin[0] + qin[1] * qin[1] + qin[2] * qin[2] + qin[3] * qin[3];
+    qmag       = rsqrtf(qmag);
+    qout[0]    = qin[0] * qmag;
+    qout[1]    = qin[1] * qmag;
+    qout[2]    = qin[2] * qmag;
+    qout[3]    = qin[3] * qmag;
+}
+
+/**
+ * @brief Perform a 3D cross product
+ *
+ * @param p Pointer to the float[3] output of the cross product (p = a x b)
+ * @param a Pointer to the float[3] of the cross product a vector.
+ * @param b Pointer to the float[3] of the cross product b vector.
+ */
+void mathCrossProduct(float* p, const float* a, const float* b)
+{
+    float tx = a[1] * b[2] - a[2] * b[1];
+    float ty = a[2] * b[0] - a[0] * b[2];
+    p[2]     = a[0] * b[1] - a[1] * b[0];
+    p[1]     = ty;
+    p[0]     = tx;
+}
+
+/**
+ * @brief Rotate a 3D vector by a quaternion
+ *
+ * @param pout Pointer to the float[3] output of the rotation
+ * @param q Pointer to the wxyz quaternion (float[4]) of the rotation.
+ * @param p Pointer to the float[3] of the vector to rotates.
+ */
+void mathRotateVectorByQuaternion(float* pout, const float* q, const float* p)
+{
+    // return v + 2.0 * cross(q.xyz, cross(q.xyz, v) + q.w * v);
+    float iqo[3];
+    mathCrossProduct(iqo, q + 1 /*.xyz*/, p);
+    iqo[0] += q[0] * p[0];
+    iqo[1] += q[0] * p[1];
+    iqo[2] += q[0] * p[2];
+    float ret[3];
+    mathCrossProduct(ret, q + 1 /*.xyz*/, iqo);
+    pout[0] = ret[0] * 2.0 + p[0];
+    pout[1] = ret[1] * 2.0 + p[1];
+    pout[2] = ret[2] * 2.0 + p[2];
+}
+
+/**
+ * @brief Rotate a 3D vector by the inverse of a quaternion
+ *
+ * @param pout Pointer to the float[3] output of the antirotation.
+ * @param q Pointer to the wxyz quaternion (float[4]) opposite of the rotation.
+ * @param p Pointer to the float[3] of the vector to antirotates.
+ */
+void mathRotateVectorByInverseOfQuaternion(float* pout, const float* q, const float* p)
+{
+    // General note: Performing a transform this way can be about 20-30% slower than a well formed 3x3 matrix.
+    // return v + 2.0 * cross(q.xyz, cross(q.xyz, v) + q.w * v);
+    float iqo[3];
+    mathCrossProduct(iqo, p, q + 1 /*.xyz*/);
+    iqo[0] += q[0] * p[0];
+    iqo[1] += q[0] * p[1];
+    iqo[2] += q[0] * p[2];
+    float ret[3];
+    mathCrossProduct(ret, iqo, q + 1 /*.xyz*/);
+    pout[0] = ret[0] * 2.0 + p[0];
+    pout[1] = ret[1] * 2.0 + p[1];
+    pout[2] = ret[2] * 2.0 + p[2];
+}

--- a/emulator/src/components/hdw-imu/quaternions.c
+++ b/emulator/src/components/hdw-imu/quaternions.c
@@ -1,0 +1,170 @@
+#include "quaternions.h"
+
+#include <math.h>
+
+/**
+ * @brief Perform a fast, approximate reciprocal square root
+ *
+ * @param x The number to take a recriprocal square root of.
+ * @return approximately 1/sqrt(x)
+ */
+float rsqrtf(float x)
+{
+    typedef union
+    {
+        int32_t i;
+        float f;
+    } fiunion;
+    const float xhalf = 0.5f * x;
+    fiunion i         = {.f = x};
+    i.i               = 0x5f375a86 - (i.i >> 1);
+    x                 = i.f;
+    x                 = x * (1.5f - xhalf * x * x);
+    x                 = x * (1.5f - xhalf * x * x);
+    return x;
+}
+
+/**
+ * @brief Perform a fast, approximate square root
+ *
+ * @param x The number to take a square root of.
+ * @return approximately sqrt(x) (but is much faster)
+ */
+float mathsqrtf(float x)
+{
+    // Trick to do approximate, fast square roots. (Though it is surprisingly fast)
+    int sign = x < 0;
+    if (sign)
+        x = -x;
+    if (x < 0.0000001)
+        return 0.0001;
+    float o = x;
+    o       = (o + x / o) / 2;
+    o       = (o + x / o) / 2;
+    o       = (o + x / o) / 2;
+    o       = (o + x / o) / 2;
+    if (sign)
+        return -o;
+    else
+        return o;
+}
+
+/**
+ * @brief convert euler angles (in radians) to a quaternion.
+ *
+ * @param q Pointer to the wxyz quat (float[4]) to be written.
+ * @param euler Pointer to a float[3] of euler angles.
+ */
+void mathEulerToQuat(float* q, const float* euler)
+{
+    float pitch = euler[0];
+    float yaw   = euler[1];
+    float roll  = euler[2];
+    float cr    = cosf(pitch * 0.5);
+    float sr    = sinf(pitch * 0.5); // Pitch: About X
+    float cp    = cosf(yaw * 0.5);
+    float sp    = sinf(yaw * 0.5); // Yaw:   About Y
+    float cy    = cosf(roll * 0.5);
+    float sy    = sinf(roll * 0.5); // Roll:  About Z
+    q[0]        = cr * cp * cy + sr * sp * sy;
+    q[1]        = sr * cp * cy - cr * sp * sy;
+    q[2]        = cr * sp * cy + sr * cp * sy;
+    q[3]        = cr * cp * sy - sr * sp * cy;
+}
+
+/**
+ * @brief Rotate one quaternion by another (and do not normalize)
+ *
+ * @param qout Pointer to the wxyz quat (float[4]) to be written.
+ * @param q1 First quaternion to be rotated.
+ * @param q2 Quaternion to rotate q1 by.
+ */
+void mathQuatApply(float* qout, const float* q1, const float* q2)
+{
+    // NOTE: Does not normalize - you will need to normalize eventually.
+    float tmpw, tmpx, tmpy;
+    tmpw    = (q1[0] * q2[0]) - (q1[1] * q2[1]) - (q1[2] * q2[2]) - (q1[3] * q2[3]);
+    tmpx    = (q1[0] * q2[1]) + (q1[1] * q2[0]) + (q1[2] * q2[3]) - (q1[3] * q2[2]);
+    tmpy    = (q1[0] * q2[2]) - (q1[1] * q2[3]) + (q1[2] * q2[0]) + (q1[3] * q2[1]);
+    qout[3] = (q1[0] * q2[3]) + (q1[1] * q2[2]) - (q1[2] * q2[1]) + (q1[3] * q2[0]);
+    qout[2] = tmpy;
+    qout[1] = tmpx;
+    qout[0] = tmpw;
+}
+
+/**
+ * @brief Normalize a quaternion
+ *
+ * @param qout Pointer to the wxyz quat (float[4]) to be written.
+ * @param qin Pointer to the quaterion to normalize.
+ */
+void mathQuatNormalize(float* qout, const float* qin)
+{
+    float qmag = qin[0] * qin[0] + qin[1] * qin[1] + qin[2] * qin[2] + qin[3] * qin[3];
+    qmag       = rsqrtf(qmag);
+    qout[0]    = qin[0] * qmag;
+    qout[1]    = qin[1] * qmag;
+    qout[2]    = qin[2] * qmag;
+    qout[3]    = qin[3] * qmag;
+}
+
+/**
+ * @brief Perform a 3D cross product
+ *
+ * @param p Pointer to the float[3] output of the cross product (p = a x b)
+ * @param a Pointer to the float[3] of the cross product a vector.
+ * @param b Pointer to the float[3] of the cross product b vector.
+ */
+void mathCrossProduct(float* p, const float* a, const float* b)
+{
+    float tx = a[1] * b[2] - a[2] * b[1];
+    float ty = a[2] * b[0] - a[0] * b[2];
+    p[2]     = a[0] * b[1] - a[1] * b[0];
+    p[1]     = ty;
+    p[0]     = tx;
+}
+
+/**
+ * @brief Rotate a 3D vector by a quaternion
+ *
+ * @param pout Pointer to the float[3] output of the rotation
+ * @param q Pointer to the wxyz quaternion (float[4]) of the rotation.
+ * @param p Pointer to the float[3] of the vector to rotates.
+ */
+void mathRotateVectorByQuaternion(float* pout, const float* q, const float* p)
+{
+    // return v + 2.0 * cross(q.xyz, cross(q.xyz, v) + q.w * v);
+    float iqo[3];
+    mathCrossProduct(iqo, q + 1 /*.xyz*/, p);
+    iqo[0] += q[0] * p[0];
+    iqo[1] += q[0] * p[1];
+    iqo[2] += q[0] * p[2];
+    float ret[3];
+    mathCrossProduct(ret, q + 1 /*.xyz*/, iqo);
+    pout[0] = ret[0] * 2.0 + p[0];
+    pout[1] = ret[1] * 2.0 + p[1];
+    pout[2] = ret[2] * 2.0 + p[2];
+}
+
+/**
+ * @brief Rotate a 3D vector by the inverse of a quaternion
+ *
+ * @param pout Pointer to the float[3] output of the antirotation.
+ * @param q Pointer to the wxyz quaternion (float[4]) opposite of the rotation.
+ * @param p Pointer to the float[3] of the vector to antirotates.
+ */
+void mathRotateVectorByInverseOfQuaternion(float* pout, const float* q, const float* p)
+{
+    // General note: Performing a transform this way can be about 20-30% slower than a well formed 3x3 matrix.
+    // return v + 2.0 * cross(q.xyz, cross(q.xyz, v) + q.w * v);
+    float iqo[3];
+    mathCrossProduct(iqo, p, q + 1 /*.xyz*/);
+    iqo[0] += q[0] * p[0];
+    iqo[1] += q[0] * p[1];
+    iqo[2] += q[0] * p[2];
+    float ret[3];
+    mathCrossProduct(ret, iqo, q + 1 /*.xyz*/);
+    pout[0] = ret[0] * 2.0 + p[0];
+    pout[1] = ret[1] * 2.0 + p[1];
+    pout[2] = ret[2] * 2.0 + p[2];
+}


### PR DESCRIPTION
### Description

Standalone math functions for quaternions, vectors, etc. are moved from `hdw-imu.c` into a separate file that can be copied wholesale between the swadge and the emulator.

### Test Instructions

Run the accel test on both the emulator and the swadge, the math should at least match up now even if the emulator doesn't really do anything.

### Ticket Links

<!--- Link any tickets that are completed in this pull request. -->

### Readiness Checklist
- [x] I have run `make format` to format the changes
- [x] I have compiled the firmware and the changes have no warnings
- [x] I have compiled the emulator and the changes have no warnings
- [x] I have run `make cppcheck` and checked that `cppcheck_result.txt` has no warnings for the changes
- [x] I have added doxygen comments to any code used by more than one Swadge mode. This includes `/*! \file` comments with Design Philosophy, Usage, and Example sections for new headers.
- [x] I have run `make docs` and checked that `doxy_warnings.txt` has no warnings for the new code
