### PR TITLE
Fix use-after free in removeSingleItemFromMenu()

### DIFF
--- a/main/menu/menu.c
+++ b/main/menu/menu.c
@@ -219,7 +219,6 @@ void removeSingleItemFromMenu(menu_t* menu, const char* label)
         menuItem_t* item = listNode->val;
         if (item->label == label)
         {
-            removeEntry(menu->items, listNode);
             if (menu->currentItem == listNode)
             {
                 if (NULL != listNode->next)
@@ -231,6 +230,7 @@ void removeSingleItemFromMenu(menu_t* menu, const char* label)
                     menu->currentItem = listNode->prev;
                 }
             }
+            removeEntry(menu->items, listNode);
             free(item);
             return;
         }


### PR DESCRIPTION
### Description


### Test Instructions

Tested with the graphics test mode currently in the `3d-rendering-api` branch, but it's pretty easy to stick it in the main menu or something and see if it crashes.

### Ticket Links

<!--- Link any tickets that are completed in this pull request. -->

### Readiness Checklist
- [x] I have run `make format` to format the changes
- [x] I have compiled the firmware and the changes have no warnings
- [x] I have compiled the emulator and the changes have no warnings
- [x] I have run `make cppcheck` and checked that `cppcheck_result.txt` has no warnings for the changes
- [x] I have added doxygen comments to any code used by more than one Swadge mode. This includes `/*! \file` comments with Design Philosophy, Usage, and Example sections for new headers.
- [x] I have run `make docs` and checked that `doxy_warnings.txt` has no warnings for the new code
