### PR TITLE
Always handle touchpad keys

### DIFF
--- a/emulator/src/extensions/touch/ext_touch.c
+++ b/emulator/src/extensions/touch/ext_touch.c
@@ -258,22 +258,22 @@ static int32_t touchKey(uint32_t key, bool down)
 {
     // Map from state to touchpad rotation. Button bits are in URLD order
     const int32_t phiMap[] = {
-          0, // 0b0000 ____ (0 radius)
+        0,   // 0b0000 ____ (0 radius)
         270, // 0b0001 ___D
         180, // 0b0010 __L_
         225, // 0b0011 __LD
-          0, // 0b0100 _R__
+        0,   // 0b0100 _R__
         315, // 0b0101 _R_D
-          0, // 0b0110 _RL_ (0 radius)
+        0,   // 0b0110 _RL_ (0 radius)
         270, // 0b0111 _RLD
-         90, // 0b1000 U___
-          0, // 0b1001 U__D (0 radius)
+        90,  // 0b1000 U___
+        0,   // 0b1001 U__D (0 radius)
         135, // 0b1010 U_L_
         180, // 0b1011 U_LD
-         45, // 0b1100 UR__
-          0, // 0b1101 UR_D
-         90, // 0b1110 URL_
-          0, // 0b1111 URLD (0 radius)
+        45,  // 0b1100 UR__
+        0,   // 0b1101 UR_D
+        90,  // 0b1110 URL_
+        0,   // 0b1111 URLD (0 radius)
     };
 
     if (key < '1' || key > '4')
@@ -293,7 +293,7 @@ static int32_t touchKey(uint32_t key, bool down)
         emuTouch.keyState &= ~(1 << keyNum);
     }
 
-    int32_t radius = 1024;
+    int32_t radius    = 1024;
     int32_t intensity = emuTouch.lastTouchIntensity;
     // Check for the canceled-out positions where
     switch (emuTouch.keyState)
@@ -302,12 +302,12 @@ static int32_t touchKey(uint32_t key, bool down)
         case 6:  // LR pressed
         case 9:  // UD pressed
         case 15: // All pressed
-        radius = 0;
-        intensity = 0;
-        break;
+            radius    = 0;
+            intensity = 0;
+            break;
 
         default:
-        break;
+            break;
     }
 
     emulatorSetTouchJoystick(phiMap[emuTouch.keyState], radius, intensity);

--- a/emulator/src/extensions/touch/ext_touch.c
+++ b/emulator/src/extensions/touch/ext_touch.c
@@ -229,11 +229,12 @@ static bool updateTouch(int32_t x, int32_t y, bool clicked)
 }
 
 /**
- * @brief Initializes the touchpad extension.
+ * @brief Initializes the touchpad extension. If emulateTouch is enabled, the touchpad will display.
+ *
+ * Using keys 1-4 to control the touchpad 1-4 is always enabled.
  *
  * @param emuArgs
- * @return true
- * @return false
+ * @return true If touchpad emulation is enabled (it is)
  */
 static bool touchInit(emuArgs_t* emuArgs)
 {
@@ -248,12 +249,9 @@ static bool touchInit(emuArgs_t* emuArgs)
     if (emuArgs->emulateTouch)
     {
         requestPane(&touchEmuCallback, PANE_BOTTOM, PANE_MIN_SIZE, PANE_MIN_SIZE);
-        return true;
     }
-    else
-    {
-        return false;
-    }
+
+    return true;
 }
 
 static int32_t touchKey(uint32_t key, bool down)


### PR DESCRIPTION
### Description

* Always enables touchpad for keys 1-4, regardless of if the emulator touchpad is displayed
* Adds support for 8-way touch when holding multiple keys, as though it were a D-pad

### Test Instructions

Test by pressing keys 1-4. 8-way touch can be tested by rolling through pairs 13, 34, 42, and 21 to go through a full rotation in 45-degree increments.

### Ticket Links

<!--- Link any tickets that are completed in this pull request. -->

### Readiness Checklist
- [x] I have run `make format` to format the changes
- [x] I have compiled the firmware and the changes have no warnings
- [x] I have compiled the emulator and the changes have no warnings
- [x] I have run `make cppcheck` and checked that `cppcheck_result.txt` has no warnings for the changes
- [x] I have added doxygen comments to any code used by more than one Swadge mode. This includes `/*! \file` comments with Design Philosophy, Usage, and Example sections for new headers.
- [x] I have run `make docs` and checked that `doxy_warnings.txt` has no warnings for the new code
