### PR TITLE
Fix touchpad functionality and text in light dances

### DIFF
--- a/main/modes/dance/dance.c
+++ b/main/modes/dance/dance.c
@@ -43,6 +43,9 @@ typedef struct
 
     uint64_t buttonPressedTimer;
 
+    touchSpinState_t spinState;
+    uint8_t startDanceSpeed;
+
     font_t infoFont;
     wsg_t arrow;
 } danceMode_t;
@@ -293,14 +296,29 @@ void dancePollTouch(void)
     int32_t phi, r, intensity;
     if (getTouchJoystick(&phi, &r, &intensity))
     {
-        // Make sure we are pressing on the edge.
-        if (intensity > 5000 && r > 512)
+        if (!danceState->spinState.startSet)
         {
-            uint8_t index = ((phi * (sizeof(danceSpeeds) / sizeof(*danceSpeeds) - 1) + 640) / 1280);
-
-            danceState->danceSpeed         = index;
-            danceState->buttonPressedTimer = 0;
+            danceState->startDanceSpeed = danceState->danceSpeed;
         }
+
+        getTouchSpins(&danceState->spinState, phi, r);
+
+        // Make sure we are pressing on the edge.
+
+        int32_t speeds = ARRAY_SIZE(danceSpeeds);
+        int32_t diff = CLAMP((
+            (
+                (danceState->spinState.spins * 360 + danceState->spinState.remainder)
+                * (speeds - 1)
+            ) / -360),
+        -speeds, speeds);
+
+        danceState->danceSpeed         = CLAMP(danceState->startDanceSpeed + diff, 0, speeds - 1);
+        danceState->buttonPressedTimer = 0;
+    }
+    else
+    {
+        danceState->spinState.startSet = false;
     }
 }
 
@@ -322,7 +340,7 @@ void danceRedrawScreen(void)
         drawWsg(&danceState->arrow, ((TFT_WIDTH - width) / 2) + width + 8, yOff, false, false, 90);
 
         // Draw the brightness at the top
-        char text[18];
+        char text[19];
         snprintf(text, sizeof(text), "Brightness: %d", getLedBrightnessSetting());
         width = textWidth(&(danceState->infoFont), text);
         yOff  = 16;
@@ -335,11 +353,11 @@ void danceRedrawScreen(void)
         yOff += danceState->infoFont.height + 16;
         if (danceSpeeds[danceState->danceSpeed] > DANCE_SPEED_MULT)
         {
-            snprintf(text, sizeof(text), "Y~X: Speed: 1/%dx", danceSpeeds[danceState->danceSpeed] / DANCE_SPEED_MULT);
+            snprintf(text, sizeof(text), "Spin: Speed: 1/%dx", danceSpeeds[danceState->danceSpeed] / DANCE_SPEED_MULT);
         }
         else
         {
-            snprintf(text, sizeof(text), "Y~X: Speed: %dx", DANCE_SPEED_MULT / danceSpeeds[danceState->danceSpeed]);
+            snprintf(text, sizeof(text), "Spin: Speed: %dx", DANCE_SPEED_MULT / danceSpeeds[danceState->danceSpeed]);
         }
         width = textWidth(&(danceState->infoFont), text);
         drawText(&(danceState->infoFont), c555, text, (TFT_WIDTH - width) / 2, yOff);

--- a/main/modes/dance/dance.c
+++ b/main/modes/dance/dance.c
@@ -18,7 +18,7 @@
 // Defines
 //==============================================================================
 
-#define RGB_2_ARG(r, g, b) ((((r) & 0xFF) << 16) | (((g) & 0xFF) << 8) | (((b) & 0xFF)))
+#define RGB_2_ARG(r, g, b) ((((r)&0xFF) << 16) | (((g)&0xFF) << 8) | (((b)&0xFF)))
 #define ARG_R(arg)         (((arg) >> 16) & 0xFF)
 #define ARG_G(arg)         (((arg) >> 8) & 0xFF)
 #define ARG_B(arg)         (((arg) >> 0) & 0xFF)
@@ -306,12 +306,9 @@ void dancePollTouch(void)
         // Make sure we are pressing on the edge.
 
         int32_t speeds = ARRAY_SIZE(danceSpeeds);
-        int32_t diff = CLAMP((
-            (
-                (danceState->spinState.spins * 360 + danceState->spinState.remainder)
-                * (speeds - 1)
-            ) / -360),
-        -speeds, speeds);
+        int32_t diff
+            = CLAMP((((danceState->spinState.spins * 360 + danceState->spinState.remainder) * (speeds - 1)) / -360),
+                    -speeds, speeds);
 
         danceState->danceSpeed         = CLAMP(danceState->startDanceSpeed + diff, 0, speeds - 1);
         danceState->buttonPressedTimer = 0;


### PR DESCRIPTION
### Description

Fixes the math in the light dances to make the touchpad work for all speeds, and makes it relative using the spins API. Also fixes the text to say "Spins" instead of "Y~X"

### Test Instructions

Open light dances mode, spin the touchpad around in both directions. It should rotate from 1/8x to 4x with one full rotation.

### Ticket Links

<!--- Link any tickets that are completed in this pull request. -->

### Readiness Checklist
- [x] I have run `make format` to format the changes
- [x] I have compiled the firmware and the changes have no warnings
- [x] I have compiled the emulator and the changes have no warnings
- [x] I have run `make cppcheck` and checked that `cppcheck_result.txt` has no warnings for the changes
- [x] I have added doxygen comments to any code used by more than one Swadge mode. This includes `/*! \file` comments with Design Philosophy, Usage, and Example sections for new headers.
- [x] I have run `make docs` and checked that `doxy_warnings.txt` has no warnings for the new code
