### PR TITLE
Screensaver

### DIFF
--- a/components/hdw-led/hdw-led.c
+++ b/components/hdw-led/hdw-led.c
@@ -169,3 +169,11 @@ uint8_t getLedState(led_t* leds, uint8_t numLeds)
 
     return 0;
 }
+
+/**
+ * @brief Wait until any pending LED transactions are finished, then return
+ */
+void flushLeds(void)
+{
+    rmt_tx_wait_all_done(led_chan, -1);
+}

--- a/components/hdw-led/include/hdw-led.h
+++ b/components/hdw-led/include/hdw-led.h
@@ -25,6 +25,11 @@
  * Brightness is adjusted per-color-channel, so dimming may produce different colors.
  * setLedBrightnessSetting() should be called instead if the brightness change should be persistent through reboots.
  *
+ * flushLeds() may be called to wait until all pending LED transactions are completed. This does not need to be called
+ * under normal operation. The RMT peripheral handles updating LEDs in the background automatically, but transactions
+ * must be flushed before entering light sleep. If they are not, garbage data may be sent after light sleep begins,
+ * resulting in indeterminate LED behavior.
+ *
  * Even though \c CONFIG_NUM_LEDS declares eight LEDs, there is a ninth LED which is controllable. By default, setting
  * \c CONFIG_NUM_LEDS LEDs will automatically set the ninth to the average of the sixth, seventh, and eighth, which
  * surround it on the PCB. To set the ninth LED, set `CONFIG_NUM_LEDS + 1` LEDs.
@@ -70,5 +75,6 @@ esp_err_t deinitLeds(void);
 esp_err_t setLeds(led_t* leds, uint8_t numLeds);
 void setLedBrightness(uint8_t brightness);
 uint8_t getLedState(led_t* leds, uint8_t numLeds);
+void flushLeds(void);
 
 #endif

--- a/emulator/src/components/hdw-led/hdw-led.c
+++ b/emulator/src/components/hdw-led/hdw-led.c
@@ -105,3 +105,12 @@ led_t* getLedMemory(uint8_t* numLeds)
     *numLeds = CONFIG_NUM_LEDS;
     return rdLeds;
 }
+
+/**
+ * @brief Wait until any pending LED transactions are finished, then return
+ * Immediately returns on the emulator
+ */
+void flushLeds(void)
+{
+    return;
+}

--- a/main/modes/dance/dance.c
+++ b/main/modes/dance/dance.c
@@ -223,11 +223,14 @@ void danceMainLoop(int64_t elapsedUs)
     // Only sleep with a blank screen, otherwise the screen flickers
     if (danceState->blankScreen)
     {
-        // Light sleep for 4ms. The longer the sleep, the choppier the LED animations
-        // 4ms looks pretty good, though some LED timers do run faster (like 'rise')
-        // TODO this isn't working, but it used to?
-        // esp_sleep_enable_timer_wakeup(4000);
-        // esp_light_sleep_start();
+        // Wait for any LED transactions to finish, otherwise RMT will do weird things during CPU sleep
+        flushLeds();
+        /* Light sleep for 40ms (see DEFAULT_FRAME_RATE_US).
+         * The longer the sleep, the choppier the LED animations.
+         * Sleeping longer than the current framerate will look worse
+         */
+        esp_sleep_enable_timer_wakeup(DEFAULT_FRAME_RATE_US);
+        esp_light_sleep_start();
     }
 }
 

--- a/main/modes/mainMenu/mainMenu.c
+++ b/main/modes/mainMenu/mainMenu.c
@@ -43,6 +43,7 @@ typedef struct
     int32_t cheatCodeIdx;
     bool debugMode;
     bool fanfarePlaying;
+    int32_t autoLightDanceTimer;
 } mainMenu_t;
 
 //==============================================================================
@@ -208,10 +209,23 @@ static void mainMenuExitMode(void)
  */
 static void mainMenuMainLoop(int64_t elapsedUs)
 {
+    // Increment this timer
+    mainMenu->autoLightDanceTimer += elapsedUs;
+    // If 10s have elapsed with no user input
+    if (getScreensaverTimeSetting() != 0 && mainMenu->autoLightDanceTimer >= (getScreensaverTimeSetting() * 1000000))
+    {
+        // Switch to the LED dance mode
+        switchToSwadgeMode(&danceMode);
+        return;
+    }
+
     // Pass all button events to the menu
     buttonEvt_t evt = {0};
     while (checkButtonQueueWrapper(&evt))
     {
+        // Any button event resets this timer
+        mainMenu->autoLightDanceTimer = 0;
+
         if ((!mainMenu->debugMode) && (evt.down))
         {
             if (evt.button == cheatCode[mainMenu->cheatCodeIdx])

--- a/main/swadge2024.c
+++ b/main/swadge2024.c
@@ -157,8 +157,7 @@
     #define RTC_DATA_ATTR
 #endif
 
-#define EXIT_TIME_US          1000000
-#define DEFAULT_FRAME_RATE_US 40000
+#define EXIT_TIME_US 1000000
 
 //==============================================================================
 // Variables

--- a/main/swadge2024.h
+++ b/main/swadge2024.h
@@ -207,6 +207,9 @@
 #include "settingsManager.h"
 #include "touchUtils.h"
 
+/// @brief the default time between drawn frames, in microseconds
+#define DEFAULT_FRAME_RATE_US 40000
+
 /**
  * @struct swadgeMode_t
  * @brief A struct of all the function pointers necessary for a swadge mode. If a mode does not need a particular


### PR DESCRIPTION
### Description

Added screensaver timeout from main menu.
Added light sleep during LED animations.

### Test Instructions

* Must be run on actual hardware
* Wait on the main menu to enter LED animation mode
* Wait on LED animation mode to turn off the display
* Make sure the LED behavior is sane when the display is off

### Ticket Links

n/a

### Readiness Checklist
- [x] I have run `make format` to format the changes
- [x] I have compiled the firmware and the changes have no warnings
- [x] I have compiled the emulator and the changes have no warnings
- [x] I have run `make cppcheck` and checked that `cppcheck_result.txt` has no warnings for the changes
- [x] I have added doxygen comments to any code used by more than one Swadge mode. This includes `/*! \file` comments with Design Philosophy, Usage, and Example sections for new headers.
- [x] I have run `make docs` and checked that `doxy_warnings.txt` has no warnings for the new code
