### PR TITLE
Add setting option to use the swadge rotated 180 degrees

### DIFF
--- a/components/hdw-btn/hdw-btn.c
+++ b/components/hdw-btn/hdw-btn.c
@@ -42,6 +42,8 @@ static int numTouchPads;
 static touch_pad_t* touchPads;
 // Used in getBaseTouchVals() to get zeroed touch sensor values
 static int32_t* baseOffsets = NULL;
+// Used to rotate touches by 180 degrees if needed
+static bool flipTouch;
 
 /// Timer handle used to periodically poll buttons
 static gptimer_handle_t btnTimer = NULL;
@@ -54,7 +56,7 @@ static void initPushButtons(gpio_num_t* pushButtons, uint8_t numPushButtons);
 static bool btn_timer_isr_cb(gptimer_handle_t timer, const gptimer_alarm_event_data_t* edata, void* user_ctx);
 
 static void initTouchSensor(touch_pad_t* _touchPads, uint8_t _numTouchPads, float touchPadSensitivity,
-                            bool denoiseEnable);
+                            bool denoiseEnable, bool flipTouch);
 
 static int getTouchRawValues(uint32_t* rawValues, int maxPads);
 static int getBaseTouchVals(int32_t* data, int count);
@@ -72,13 +74,13 @@ static int getBaseTouchVals(int32_t* data, int count);
  * @param touchPads A list of touch areas that make up a touchpad to initialize.
  * @param numTouchPads The number of touch buttons to initialize
  */
-void initButtons(gpio_num_t* pushButtons, uint8_t numPushButtons, touch_pad_t* touchPads, uint8_t numTouchPads)
+void initButtons(gpio_num_t* pushButtons, uint8_t numPushButtons, touch_pad_t* touchPads, uint8_t numTouchPads, bool _flipTouch)
 {
     // create a queue to handle polling GPIO from ISR
     btn_evt_queue = xQueueCreate(3 * (numPushButtons + numTouchPads), sizeof(uint32_t));
 
     initPushButtons(pushButtons, numPushButtons);
-    initTouchSensor(touchPads, numTouchPads, 0.2f, true);
+    initTouchSensor(touchPads, numTouchPads, 0.2f, true, _flipTouch);
 }
 
 /**
@@ -276,7 +278,7 @@ static bool IRAM_ATTR btn_timer_isr_cb(gptimer_handle_t timer, const gptimer_ala
  * @param denoiseEnable true to denoise the input, false to use it raw
  */
 static void initTouchSensor(touch_pad_t* _touchPads, uint8_t _numTouchPads, float touchPadSensitivity,
-                            bool denoiseEnable)
+                            bool denoiseEnable, bool _flipTouch)
 {
     ESP_LOGD("TOUCH", "Initializing touch pad");
 
@@ -351,6 +353,8 @@ static void initTouchSensor(touch_pad_t* _touchPads, uint8_t _numTouchPads, floa
         ESP_LOGD("TOUCH", "touch pad [%d] base %lu, thresh %lu", touchPads[i], touch_value,
                  (uint32_t)(touch_value * touchPadSensitivity));
     }
+
+    flipTouch = _flipTouch;
 
     getTouchJoystick(0, 0, 0);
 }
@@ -524,7 +528,7 @@ int getTouchJoystick(int32_t* phi, int32_t* r, int32_t* intensity)
     ringPh = (ringPh * 9) >> 5;
     if (phi)
     {
-        *phi = ringPh;
+        *phi = (flipTouch ? ((ringPh + 180) % 360) : ringPh);
     }
 
     // Find ratio of ring to inner.

--- a/components/hdw-btn/include/hdw-btn.h
+++ b/components/hdw-btn/include/hdw-btn.h
@@ -120,7 +120,7 @@ typedef struct
     bool down;          //!< True if the button was pressed, false if it was released
 } buttonEvt_t;
 
-void initButtons(gpio_num_t* pushButtons, uint8_t numPushButtons, touch_pad_t* touchPads, uint8_t numTouchPads);
+void initButtons(gpio_num_t* pushButtons, uint8_t numPushButtons, touch_pad_t* touchPads, uint8_t numTouchPads, bool flipTouch);
 void deinitButtons(void);
 bool checkButtonQueue(buttonEvt_t*);
 

--- a/components/hdw-imu/hdw-imu.c
+++ b/components/hdw-imu/hdw-imu.c
@@ -94,6 +94,8 @@ typedef enum __attribute__((packed))
 
 LSM6DSLData LSM6DSL;
 
+static bool flipImu;
+
 //==============================================================================
 // Static Function Prototypes
 //==============================================================================
@@ -259,8 +261,9 @@ static int ReadLSM6DSL(uint8_t* data, int data_len)
  * GPIO_PULLUP_ENABLE if internal pull-ups should be used
  * @return ESP_OK if the accelerometer initialized, or a non-zero value if it did not
  */
-esp_err_t initAccelerometer(gpio_num_t sda, gpio_num_t scl, gpio_pullup_t pullup)
+esp_err_t initAccelerometer(gpio_num_t sda, gpio_num_t scl, gpio_pullup_t pullup, bool flip)
 {
+    flipImu = flip;
     int i;
     int retry = 0;
 do_retry:
@@ -507,7 +510,7 @@ esp_err_t accelIntegrate()
 
         // STEP 6A: Examine vectors.  Generally speaking, we want an "up" vector, not a gravity vector.
         // this is "up" in the controller's point of view.
-        float accel_up[3] = {-accel_data[0], accel_data[1], -accel_data[2]};
+        float accel_up[3] = {-accel_data[0], flipImu?-accel_data[1]:accel_data[1], -accel_data[2]};
 
         float accel_inverse_mag
             = rsqrtf(accel_up[0] * accel_up[0] + accel_up[1] * accel_up[1] + accel_up[2] * accel_up[2]);

--- a/components/hdw-imu/include/hdw-imu.h
+++ b/components/hdw-imu/include/hdw-imu.h
@@ -44,6 +44,7 @@
 #define _HDW_IMU_H_
 
 #include <stdint.h>
+#include <stdbool.h>
 
 #include <driver/i2c.h>
 #include <hal/gpio_types.h>
@@ -84,7 +85,7 @@ typedef struct
 
 extern LSM6DSLData LSM6DSL;
 
-esp_err_t initAccelerometer(gpio_num_t sda, gpio_num_t scl, gpio_pullup_t pullup);
+esp_err_t initAccelerometer(gpio_num_t sda, gpio_num_t scl, gpio_pullup_t pullup, bool flip);
 esp_err_t deInitAccelerometer(void);
 esp_err_t accelGetAccelVecRaw(int16_t* x, int16_t* y, int16_t* z);
 esp_err_t accelGetOrientVec(int16_t* x, int16_t* y, int16_t* z);

--- a/components/hdw-tft/hdw-tft.c
+++ b/components/hdw-tft/hdw-tft.c
@@ -169,7 +169,7 @@ esp_err_t setTFTBacklightBrightness(uint8_t intensity)
  */
 void initTFT(spi_host_device_t spiHost, gpio_num_t sclk, gpio_num_t mosi, gpio_num_t dc, gpio_num_t cs, gpio_num_t rst,
              gpio_num_t backlight, bool isPwmBacklight, ledc_channel_t ledcChannel, ledc_timer_t ledcTimer,
-             uint8_t brightness)
+             uint8_t brightness, bool flip180)
 {
     tftSpiHost        = spiHost;
     tftBacklightPin   = backlight;
@@ -232,14 +232,14 @@ void initTFT(spi_host_device_t spiHost, gpio_num_t sclk, gpio_num_t mosi, gpio_n
 
     // Config the TFT
     esp_lcd_panel_swap_xy(panel_handle, SWAP_XY);
-    esp_lcd_panel_mirror(panel_handle, MIRROR_X, MIRROR_Y);
+    esp_lcd_panel_mirror(panel_handle, flip180 ? !MIRROR_X : MIRROR_X, flip180 ? !MIRROR_Y : MIRROR_Y);
     esp_lcd_panel_set_gap(panel_handle, X_OFFSET, Y_OFFSET);
 
 #if defined(CONFIG_GC9307_240x280)
     esp_lcd_panel_invert_color(panel_handle, false);
     // NOTE: the following call would override settings set by esp_lcd_panel_swap_xy() and esp_lcd_panel_mirror()
     // Both of the prior functions write to the 0x36 register
-    esp_lcd_panel_io_tx_param(tft_io_handle, 0x36, (uint8_t[]){0xE8}, 1); // MX, MY, RGB mode  (MAD CTL)
+    esp_lcd_panel_io_tx_param(tft_io_handle, 0x36, (uint8_t[]){0x28 | (flip180 ? 0x00 : 0xC0)}, 1); // MX, MY, RGB mode  (MAD CTL)
     esp_lcd_panel_io_tx_param(tft_io_handle, 0x35, (uint8_t[]){0x00}, 1); // "tear effect" testing sync pin.
 #elif defined(CONFIG_ST7735_128x160)
     esp_lcd_panel_io_tx_param(tft_io_handle, 0xB1, (uint8_t[]){0x05, 0x3C, 0x3C}, 3);

--- a/components/hdw-tft/include/hdw-tft.h
+++ b/components/hdw-tft/include/hdw-tft.h
@@ -124,7 +124,7 @@ typedef void (*fnBackgroundDrawCallback_t)(int16_t x, int16_t y, int16_t w, int1
 
 void initTFT(spi_host_device_t spiHost, gpio_num_t sclk, gpio_num_t mosi, gpio_num_t dc, gpio_num_t cs, gpio_num_t rst,
              gpio_num_t backlight, bool isPwmBacklight, ledc_channel_t ledcChannel, ledc_timer_t ledcTimer,
-             uint8_t brightness);
+             uint8_t brightness, bool flip180);
 void deinitTFT(void);
 esp_err_t setTFTBacklightBrightness(uint8_t intensity);
 void disableTFTBacklight(void);

--- a/emulator/src/components/hdw-btn/hdw-btn.c
+++ b/emulator/src/components/hdw-btn/hdw-btn.c
@@ -57,7 +57,7 @@ static int32_t lastTouchIntensity = 0;
  * @param touchPads A list of touch areas that make up a touchpad to initialize.
  * @param numTouchPads The number of touch buttons to initialize
  */
-void initButtons(gpio_num_t* pushButtons, uint8_t numPushButtons, touch_pad_t* touchPads, uint8_t numTouchPads)
+void initButtons(gpio_num_t* pushButtons, uint8_t numPushButtons, touch_pad_t* touchPads, uint8_t numTouchPads, bool flipTouch)
 {
     buttonState = 0;
     buttonQueue = calloc(1, sizeof(list_t));

--- a/emulator/src/components/hdw-imu/hdw-imu.c
+++ b/emulator/src/components/hdw-imu/hdw-imu.c
@@ -31,7 +31,7 @@ LSM6DSLData LSM6DSL;
  * GPIO_PULLUP_ENABLE if internal pull-ups should be used
  * @return ESP_OK if the accelerometer initialized, or a non-zero value if it did not
  */
-esp_err_t initAccelerometer(gpio_num_t sda, gpio_num_t scl, gpio_pullup_t pullup)
+esp_err_t initAccelerometer(gpio_num_t sda, gpio_num_t scl, gpio_pullup_t pullup, bool flip)
 {
     // Default to the swadge sitting still, face-up on a table somewhere on earth
     _accelX = 0;

--- a/emulator/src/components/hdw-tft/hdw-tft.c
+++ b/emulator/src/components/hdw-tft/hdw-tft.c
@@ -73,7 +73,7 @@ static uint8_t tftBrightness         = CONFIG_TFT_MAX_BRIGHTNESS;
  */
 void initTFT(spi_host_device_t spiHost, gpio_num_t sclk, gpio_num_t mosi, gpio_num_t dc, gpio_num_t cs, gpio_num_t rst,
              gpio_num_t backlight, bool isPwmBacklight, ledc_channel_t ledcChannel, ledc_timer_t ledcTimer,
-             uint8_t brightness)
+             uint8_t brightness, bool flip180)
 {
     // ARGB pixels
     bitmapWidth  = TFT_WIDTH;

--- a/main/swadge2024.c
+++ b/main/swadge2024.c
@@ -206,6 +206,8 @@ void app_main(void)
     // Read settings from NVS
     readAllSettings();
 
+    bool flip = getFlipSwadgeSetting();
+
     // If test mode was passed
     if (getTestModePassedSetting())
     {
@@ -252,6 +254,16 @@ void app_main(void)
         GPIO_NUM_8,  // Start
         GPIO_NUM_5   // Select
     };
+    gpio_num_t pushButtonsFlip[] = {
+        GPIO_NUM_4,  // Down
+        GPIO_NUM_0,  // Up
+        GPIO_NUM_1,  // Right
+        GPIO_NUM_2,  // Left
+        GPIO_NUM_15, // B
+        GPIO_NUM_16, // A
+        GPIO_NUM_5,  // Select
+        GPIO_NUM_8,  // Start
+    };
     touch_pad_t touchPads[] = {
         TOUCH_PAD_NUM9,  // GPIO_NUM_9
         TOUCH_PAD_NUM10, // GPIO_NUM_10
@@ -260,8 +272,8 @@ void app_main(void)
         TOUCH_PAD_NUM13, // GPIO_NUM_13
         TOUCH_PAD_NUM14, // GPIO_NUM_14
     };
-    initButtons(pushButtons, sizeof(pushButtons) / sizeof(pushButtons[0]), touchPads,
-                sizeof(touchPads) / sizeof(touchPads[0]));
+    initButtons(flip ? pushButtonsFlip : pushButtons, sizeof(pushButtons) / sizeof(pushButtons[0]), touchPads,
+                sizeof(touchPads) / sizeof(touchPads[0]), flip);
 
     // Init buzzer. This must be called before initMic()
     initBuzzer(GPIO_NUM_40, LEDC_TIMER_0, LEDC_CHANNEL_0, //
@@ -289,7 +301,8 @@ void app_main(void)
             true,                       // PWM backlight
             LEDC_CHANNEL_2,             // Channel to use for PWM backlight
             LEDC_TIMER_2,               // Timer to use for PWM backlight
-            getTftBrightnessSetting()); // TFT Brightness
+            getTftBrightnessSetting(),  // TFT Brightness
+            flip);                      // Flip Display
 
     // Initialize the RGB LEDs
     initLeds(GPIO_NUM_39, GPIO_NUM_18, getLedBrightnessSetting());
@@ -306,7 +319,8 @@ void app_main(void)
     {
         initAccelerometer(GPIO_NUM_3,  // SDA
                           GPIO_NUM_41, // SCL
-                          GPIO_PULLUP_ENABLE);
+                          GPIO_PULLUP_ENABLE,
+                          flip);
         accelIntegrate();
     }
 

--- a/main/utils/settingsManager.c
+++ b/main/utils/settingsManager.c
@@ -58,6 +58,7 @@ DECL_SETTING(led_br, 0, MAX_LED_BRIGHTNESS, 5);
 DECL_SETTING(mic, 0, MAX_MIC_GAIN, MAX_MIC_GAIN);
 DECL_SETTING(cc_mode, ALL_SAME_LEDS, LINEAR_LEDS, ALL_SAME_LEDS);
 DECL_SETTING(scrn_sv, 0, 300, 20);
+DECL_SETTING(flip, 0, 1, 0);
 
 //==============================================================================
 // Static Function Prototypes
@@ -158,6 +159,9 @@ void readAllSettings(void)
 
     // Read the screensaver setting
     readSetting(&scrn_sv_setting);
+
+    // Read the flip setting
+    readSetting(&flip_setting);
 }
 
 //==============================================================================
@@ -473,4 +477,19 @@ bool getTestModePassedSetting(void)
 bool setTestModePassedSetting(bool status)
 {
     return setSetting(&test_setting, status);
+}
+
+bool getFlipSwadgeSetting(void)
+{
+    return flip_setting.val;
+}
+
+const settingParam_t* getFlipSwadgeSettingBounds(void)
+{
+    return &flip_param;
+}
+
+bool setFlipSwadgeSetting(bool val)
+{
+    return setSetting(&flip_setting, val);
 }

--- a/main/utils/settingsManager.h
+++ b/main/utils/settingsManager.h
@@ -127,4 +127,8 @@ bool setColorchordModeSetting(colorchordMode_t);
 bool getTestModePassedSetting(void);
 bool setTestModePassedSetting(bool status);
 
+bool getFlipSwadgeSetting(void);
+const settingParam_t* getFlipSwadgeSettingBounds(void);
+bool setFlipSwadgeSetting(bool val);
+
 #endif


### PR DESCRIPTION
### Description

Adds a "Reverse Thrust!" option in the menu which lets you use the swadge rotated 180 degrees! Not sure if this is something we want, but it turned out to be easier than I thought, so why not?

### Test Instructions

Test on hardware. Make sure that the buttons, screen, touchpad, and accelerometer all follow the rotation in a logical way.

### Ticket Links

<!--- Link any tickets that are completed in this pull request. -->

### Readiness Checklist
- [ ] I have run `make format` to format the changes
- [ ] I have compiled the firmware and the changes have no warnings
- [ ] I have compiled the emulator and the changes have no warnings
- [ ] I have run `make cppcheck` and checked that `cppcheck_result.txt` has no warnings for the changes
- [ ] I have added doxygen comments to any code used by more than one Swadge mode. This includes `/*! \file` comments with Design Philosophy, Usage, and Example sections for new headers.
- [ ] I have run `make docs` and checked that `doxy_warnings.txt` has no warnings for the new code
