### PR TITLE
Enable touch by default

### DIFF
--- a/emulator/src/extensions/emu_args.c
+++ b/emulator/src/extensions/emu_args.c
@@ -103,7 +103,7 @@ emuArgs_t emulatorArgs = {
     .motionJitterAmount = 5,
     .motionDrift        = false,
 
-    .emulateTouch = false,
+    .emulateTouch = true,
 
     .record   = false,
     .playback = false,


### PR DESCRIPTION
### Description

Everyone just yelled at me to do it, so I did it. Better late than never...

### Test Instructions

<!--- How was this tested? -->

### Ticket Links

<!--- Link any tickets that are completed in this pull request. -->

### Readiness Checklist
- [x] I have run `make format` to format the changes
- [x] I have compiled the firmware and the changes have no warnings
- [x] I have compiled the emulator and the changes have no warnings
- [x] I have run `make cppcheck` and checked that `cppcheck_result.txt` has no warnings for the changes
- [x] I have added doxygen comments to any code used by more than one Swadge mode. This includes `/*! \file` comments with Design Philosophy, Usage, and Example sections for new headers.
- [x] I have run `make docs` and checked that `doxy_warnings.txt` has no warnings for the new code
