### PR TITLE
Make usb usable for advanced modes

### DIFF
--- a/tools/sandbox_test/usbhid_test/Makefile
+++ b/tools/sandbox_test/usbhid_test/Makefile
@@ -1,0 +1,46 @@
+all : ../sandbox_upload run ../sandbox_interactive
+
+UNAME := $(shell uname)
+
+ifeq ($(UNAME), Linux)
+CFLAGS:=-g -O0
+LDFLAGS:=-ludev
+CC:=gcc
+else
+CFLAGS:=-Os -s
+CC:=gcc
+LDFLAGS:=C:/windows/system32/setupapi.dll
+endif
+
+SYSELF:=../../../build/swadge2024.elf
+
+build : 
+	mkdir -p build
+
+sandbox.o : ../buildhelp sandbox.c $(SYSELF) build
+	../buildhelp $(SYSELF) ../../..
+	xtensa-esp32s2-elf-objdump -s build/sandbox.o > build/debug_sandbox_s.txt
+	xtensa-esp32s2-elf-objdump -t build/sandbox.o > build/debug_sandbox_t.txt
+	xtensa-esp32s2-elf-objdump -S build/sandbox.o > build/debug_sandbox_S.txt
+
+run : ../sandbox_upload sandbox.o
+	../sandbox_upload
+
+../buildhelp : ../buildhelp.c
+	$(CC) $(CFLAGS) -o $@ $^ $(LDFLAGS)
+
+../sandbox_upload : ../sandbox_upload.c
+	$(CC) $(CFLAGS) -o $@ $^ $(LDFLAGS)
+
+../sandbox_interactive : ../sandbox_interactive.c
+	$(CC) $(CFLAGS) -o $@ $^ $(LDFLAGS)
+
+monitor : sandbox_interactive
+	../sandbox_interactive
+
+interactive : ../sandbox_interactive build
+	../sandbox_interactive sandbox.c sandbox.S $(SYSELF)
+
+clean :
+	rm -rf *.o *~ buildhelp build/debug_sandbox_s.txt build/debug_sandbox_t.txt build/debug_sandbox_S.txt build/sandbox_inst.bin build/sandbox_data.bin build/buildhelp build/sandbox.o sandbox_upload build/sandbox.lds build/provided.lds build/sandbox_symbols.txt build/system_symbols.txt sandbox_interactive buildhelp.exe sandbox_upload.exe
+

--- a/tools/sandbox_test/usbhid_test/sandbox.S
+++ b/tools/sandbox_test/usbhid_test/sandbox.S
@@ -1,0 +1,60 @@
+# This is a .S file.  While you can operate with volatile __asm__, it's easier many
+# times to use a .S file.  Which lets you freely write assembly.
+
+# Because this is a .S file you actually can #include things, etc.
+
+#include "soc/gpio_reg.h"
+
+# You can use this reference: https://0x04.net/~mwk/doc/xtensa.pdf
+# A guide on how to use gas (this .S format) is here:
+#    https://ftp.gnu.org/old-gnu/Manuals/gas-2.9.1/html_chapter/as_7.html
+#    https://dl.espressif.com/github_assets/espressif/xtensa-isa-doc/releases/download/latest/Xtensa.pdf
+
+.align 4
+
+# A little weird, you store referneces and big constants up here, before your code.
+# Then you reference it below.
+
+_advanced_usb_printf_head:	.long advanced_usb_printf_head
+_GPIO_IN_REG:				.long GPIO_IN_REG
+
+#  uint32_t test_function( uint32_t parameter )
+#   a2 is the first parameter, then a3, etc.
+#   a2 is also the return value.
+#   See this for more ABI info: http://wiki.linux-xtensa.org/index.php/ABI_Interface
+#
+#  This function will take on one parameter, shift it up by 16, then or it with the
+#  value read from advanced_usb_printf_head
+#
+.align 4
+.global test_function
+test_function:
+	entry sp, 32       # This saves off some of the registers we're using
+	l32r a3, _advanced_usb_printf_head
+	slli a2, a2, 16    # Putting this code here hides the latency from the l32r
+	l32i a3, a3, 0
+	or a2, a2, a3
+	retw              # This restores the registers.
+
+.align 4
+.global minimal_function
+minimal_function:
+	entry	sp, 16
+	retw
+
+
+.align 4
+.global asm_read_gpio
+asm_read_gpio:
+	entry	sp, 16
+
+	l32r a2, _GPIO_IN_REG
+
+	# you can actually fit 6 instructions in here, for free if they don't rely on the result.
+	# Most of the time it doesn't work out that nicely, but here it happened to.
+	# l32r's are really, _realy_ slow.
+
+	l32i a2, a2, 0
+	retw
+
+

--- a/tools/sandbox_test/usbhid_test/sandbox.c
+++ b/tools/sandbox_test/usbhid_test/sandbox.c
@@ -1,0 +1,191 @@
+#include <stdio.h>
+#include <string.h>
+#include "esp_system.h"
+#include "swadge2024.h"
+#include "hal/gpio_types.h"
+#include "esp_log.h"
+#include "soc/efuse_reg.h"
+#include "soc/soc.h"
+#include "soc/system_reg.h"
+#include "hdw-tft.h"
+#include "soc/rtc_cntl_reg.h"
+#include "soc/gpio_reg.h"
+#include "soc/io_mux_reg.h"
+#include "rom/gpio.h"
+#include "soc/i2c_reg.h"
+#include "soc/gpio_struct.h"
+#include "coreutil.h"
+#include "hdw-btn.h"
+#include "hdw-imu.h"
+
+int bQuit = 0;
+int global_i = 100;
+
+font_t ibm;
+
+
+// External functions defined in .S file for you assembly people.
+void minimal_function();
+uint32_t test_function( uint32_t x );
+uint32_t asm_read_gpio();
+
+extern fnAdvancedUsbHandler advancedUsbHandler;
+int16_t sandboxAdvancedUSB(uint8_t* buffer, uint16_t length, uint8_t isGet);
+
+static char* local_hid_string_descriptor[5] = {
+    // array of pointer to string descriptors
+    (char[]){0x09, 0x04},   // 0: is supported language is English (0x0409)
+    "Magfest",              // 1: Manufacturer
+    "Swadge Controller",    // 2: Product
+    "XXXXXX",               // 3: Serials, should use chip ID
+    "Swadge HID interface", // 4: HID
+};
+
+
+// clang-format off
+#define TUD_HID_REPORT_DESC_NIL(...) \
+  HID_USAGE_PAGE ( HID_USAGE_PAGE_DESKTOP     )                 ,\
+  HID_USAGE      ( HID_USAGE_DESKTOP_GAMEPAD  )                 ,\
+  HID_COLLECTION ( HID_COLLECTION_APPLICATION )                 ,\
+    /* Allow for 0xaa (regular size), 0xab (jumbo sized) and 0xac mini feature reports; Windows needs specific id'd and size'd endpoints. */ \
+    HID_REPORT_COUNT ( CFG_TUD_ENDPOINT0_SIZE                 ) ,\
+    HID_REPORT_SIZE  ( 8                                      ) ,\
+    HID_REPORT_ID    ( 0xaa                                   ) \
+    HID_USAGE        ( HID_USAGE_DESKTOP_GAMEPAD              ) ,\
+    HID_FEATURE      ( HID_DATA | HID_ARRAY | HID_ABSOLUTE    ) ,\
+    HID_REPORT_COUNT ( (255-1)         ) ,\
+    HID_REPORT_ID    ( 0xab                                   ) \
+    HID_USAGE        ( HID_USAGE_DESKTOP_GAMEPAD              ) ,\
+    HID_FEATURE      ( HID_DATA | HID_ARRAY | HID_ABSOLUTE    ) ,\
+    HID_REPORT_COUNT ( 1                                      ) ,\
+    HID_REPORT_ID    ( 0xac                                   ) \
+    HID_USAGE        ( HID_USAGE_DESKTOP_GAMEPAD              ) ,\
+    HID_FEATURE      ( HID_DATA | HID_ARRAY | HID_ABSOLUTE    ) ,\
+    HID_REPORT_COUNT ( (255-1)         ) ,\
+    HID_REPORT_ID    ( 0xad                                   ) \
+    HID_USAGE        ( HID_USAGE_DESKTOP_GAMEPAD              ) ,\
+    HID_FEATURE      ( HID_DATA | HID_ARRAY | HID_ABSOLUTE    ) ,\
+  HID_COLLECTION_END
+// clang-format on
+
+static const uint8_t local_hid_report_descriptor[] = {TUD_HID_REPORT_DESC_NIL()};
+
+static const uint8_t local_hid_configuration_descriptor[] = {
+    TUD_CONFIG_DESCRIPTOR(1,                                                        // Configuration number
+                          1,                                                        // interface count
+                          0,                                                        // string index
+                          (TUD_CONFIG_DESC_LEN + (CFG_TUD_HID * TUD_HID_DESC_LEN)), // total length
+                          TUSB_DESC_CONFIG_ATT_REMOTE_WAKEUP,                       // attribute
+                          100),                                                     // power in mA
+
+    TUD_HID_DESCRIPTOR(0,                             // Interface number
+                       4,                             // string index
+                       false,                         // boot protocol
+                       sizeof(local_hid_report_descriptor), // report descriptor len
+                       0x81,                          // EP In address
+                       64,                            // size
+                       1),                           // polling interval
+};
+
+
+
+void sandbox_main(void)
+{
+	bQuit = 0;
+
+	ESP_LOGI( "sandbox", "Running from IRAM. %d", global_i );
+
+	extern const tusb_desc_device_t descriptor_dev_kconfig;
+	void tinyusb_set_descriptor( const tusb_desc_device_t * dev_descriptor, const char **str_desc, int str_desc_count, const uint8_t *cfg_desc);
+	initTusb( (const tinyusb_config_t *)&descriptor_dev_kconfig, local_hid_report_descriptor );
+    tinyusb_set_descriptor(&descriptor_dev_kconfig, local_hid_string_descriptor, 5, local_hid_configuration_descriptor);
+	tud_disconnect();
+    tusb_init();
+	int i;	for( i = 0; i < 10000; i++ ) asm volatile( "nop" ); tud_connect();
+
+	advancedUsbHandler = sandboxAdvancedUSB;
+
+    loadFont("ibm_vga8.font", &ibm, false);
+
+	fillDisplayArea(0, 0, 280, 240, 5 );
+
+	setFrameRateUs(5000);
+
+	ESP_LOGI( "sandbox", "Loaded" );
+}
+
+int16_t sandboxAdvancedUSB(uint8_t* buffer, uint16_t length, uint8_t isGet)
+{
+	// The send/receive buffers are 64 bytes.
+	if( isGet )
+	{
+		// When sending data back to the host, we don't need to prefix the report descriptor.
+		buffer[0] = 0xaa;
+		buffer[1] = 0x55;
+		buffer[2] = 0xaa;
+		buffer[3] = 0x55;
+		return 64;
+	}
+	else
+	{
+		char st[128];
+		// When getting data, buffer[0] is always 0xad, our report ID, so we only have 63 bytes actually available.
+		switch( buffer[1] )
+		{
+			case 1: // Draw pixel
+			{
+				int x = buffer[2];
+				int y = buffer[3];
+				int len = buffer[4];  // Need length redundantly, because Windows can't send variable sized reports.
+				int color = buffer[5];
+				char st[64] = { 0 };
+				if( len > length - 6 ) len = length - 6;
+				if( len > 63 ) len = 63;
+				int i;
+				for( i = 0; i < len; i++ )
+				{
+					uint8_t c = buffer[5+i];
+					if( c < 127 && c > 31 )
+						st[i] = c;
+				}
+				st[len] = 0;
+				drawText( &ibm, color, st, x, y );
+				break;
+			}
+			default:
+				sprintf( st, "RX From Host %d [%02x %02x %02x %02x...]", length, buffer[0], buffer[1], buffer[2], buffer[3] );
+				drawText( &ibm, 215, st, 10, 20 );
+				break;
+		}
+		return 0;
+	}
+}
+
+void sandbox_exit()
+{
+	bQuit = 1;
+}
+
+void sandbox_tick()
+{
+	if( bQuit ) return;
+}
+
+
+swadgeMode_t sandbox_mode = {
+	.modeName				= "hidsandbox",
+	.wifiMode				= NO_WIFI,
+	.overrideUsb			= true,
+	.usesAccelerometer		= true,
+	.usesThermometer		= false,
+	.fnEnterMode			= sandbox_main,
+	.fnExitMode				= sandbox_exit,
+	.fnMainLoop				= sandbox_tick,
+	.fnAudioCallback		= NULL,
+	.fnBackgroundDrawCallback = NULL,
+	.fnEspNowRecvCb			= NULL,
+	.fnEspNowSendCb			= NULL,
+	.fnAdvancedUSB			= sandboxAdvancedUSB,
+};
+
+

--- a/tools/sandbox_test/usbhid_test/test/Makefile
+++ b/tools/sandbox_test/usbhid_test/test/Makefile
@@ -1,0 +1,8 @@
+all : hidtest
+
+hidtest : hidtest.c
+	gcc -o $@ $^ -ludev
+
+clean :
+	rm -rf hidtest
+

--- a/tools/sandbox_test/usbhid_test/test/hidtest.c
+++ b/tools/sandbox_test/usbhid_test/test/hidtest.c
@@ -6,6 +6,7 @@
 
 #include "../../../hidapi.h"
 #include "../../../hidapi.c"
+#include "../../../../emulator/src/sound/os_generic.h"
 
 #define VID 0x303a
 #define PID 0x4004
@@ -38,6 +39,31 @@ int main( int argc, char ** argv )
 	}
 	printf( "\n" );
 
+	double dStart = OGGetAbsoluteTime();
+	for( i = 0; i < 1024; i++ )
+	{
+		r = hid_get_feature_report( hd, rdata, reg_packet_length );
+		if( r != reg_packet_length )
+		{
+			fprintf( stderr, "Error reading message (%d)\n", r );
+		}
+	}
+	double dEnd = OGGetAbsoluteTime();
+	printf( "Reads: %5.0f/sec / %3.0f kB/s\n", 1024.0/(dEnd - dStart), (1024.0*63)/(dEnd - dStart));
+
+	dStart = OGGetAbsoluteTime();
+	for( i = 0; i < 1024; i++ )
+	{
+		rdata[0] = 173;
+		rdata[1] = 0x02;
+		r = hid_send_feature_report( hd, rdata, reg_packet_length );
+		if( r != reg_packet_length )
+		{
+			fprintf( stderr, "Error reading message (%d)\n", r );
+		}
+	}
+	dEnd = OGGetAbsoluteTime();
+	printf( "Writes: %5.0f/sec / %3.0f kB/s\n", 1024.0/(dEnd - dStart), (1024.0*63)/(dEnd - dStart) );
 
 	rdata[0] = 173;
 	rdata[1] = 0x00;
@@ -46,7 +72,7 @@ int main( int argc, char ** argv )
 	rdata[4] = 0xa5;
 	rdata[5] = 0x5a;
 	r = hid_send_feature_report( hd, rdata, reg_packet_length );
-	printf( "Sent data %d\n", r );
+	printf( "Sent data %d / %02x %02x %02x\n", r, rdata[1], rdata[2], rdata[3] );
 
 	int x, y;
 	int f;

--- a/tools/sandbox_test/usbhid_test/test/hidtest.c
+++ b/tools/sandbox_test/usbhid_test/test/hidtest.c
@@ -1,0 +1,72 @@
+#include <stdio.h>
+#include <stdint.h>
+#include <unistd.h>
+#include <sys/stat.h>
+#include <time.h>
+
+#include "../../../hidapi.h"
+#include "../../../hidapi.c"
+
+#define VID 0x303a
+#define PID 0x4004
+
+#ifdef WIN32
+const int reg_packet_length = 65;
+#else
+const int reg_packet_length = 64;
+#endif
+
+hid_device * hd;
+
+int main( int argc, char ** argv )
+{
+	int r;
+
+	hid_init();
+	hd = hid_open( VID, PID, 0 );
+	if( !hd ) { fprintf( stderr, "Could not open USB\n" ); return -94; }
+
+	// Disable tick.
+	uint8_t rdata[65] = { 0 };
+	rdata[0] = 173;
+	r = hid_get_feature_report( hd, rdata, reg_packet_length );
+	printf( "Got data: %d bytes\n", r );
+	int i;
+	for( i = 0; i < r; i++ )
+	{
+		printf( "%02x ", rdata[i] );
+	}
+	printf( "\n" );
+
+
+	rdata[0] = 173;
+	rdata[1] = 0x00;
+	rdata[2] = 0xa5;
+	rdata[3] = 0x5a;
+	rdata[4] = 0xa5;
+	rdata[5] = 0x5a;
+	r = hid_send_feature_report( hd, rdata, reg_packet_length );
+	printf( "Sent data %d\n", r );
+
+	int x, y;
+	int f;
+	for( f = 0; f < 10; f++ )
+	{
+		for( y = 0; y < 240; y++ )
+		{
+			for( x = 0; x < 280; x += 56 )
+			{
+				rdata[0] = 173;
+				rdata[1] = 0x01;
+				rdata[2] = x;
+				rdata[3] = y;
+				rdata[4] = 56;
+				for( i = 0; i < 56; i++ )
+					rdata[i+5] = rand();
+				r = hid_send_feature_report( hd, rdata, reg_packet_length );
+			}
+		}
+	}
+
+	hid_close( hd );
+}

--- a/tools/sandbox_test/usbhid_test/test/hidtest.c
+++ b/tools/sandbox_test/usbhid_test/test/hidtest.c
@@ -49,7 +49,7 @@ int main( int argc, char ** argv )
 		}
 	}
 	double dEnd = OGGetAbsoluteTime();
-	printf( "Reads: %5.0f/sec / %3.0f kB/s\n", 1024.0/(dEnd - dStart), (1024.0*63)/(dEnd - dStart));
+	printf( "Reads: %5.0f/sec / %3.2f kB/s\n", 1024.0/(dEnd - dStart), (63)/(dEnd - dStart));
 
 	dStart = OGGetAbsoluteTime();
 	for( i = 0; i < 1024; i++ )
@@ -63,7 +63,7 @@ int main( int argc, char ** argv )
 		}
 	}
 	dEnd = OGGetAbsoluteTime();
-	printf( "Writes: %5.0f/sec / %3.0f kB/s\n", 1024.0/(dEnd - dStart), (1024.0*63)/(dEnd - dStart) );
+	printf( "Writes: %5.0f/sec / %3.2f kB/s\n", 1024.0/(dEnd - dStart), (63)/(dEnd - dStart) );
 
 	rdata[0] = 173;
 	rdata[1] = 0x00;


### PR DESCRIPTION
This makes it possible to use advanced USB modes with custom descriptors at a later time, alleviating need for special usb modes now.

This includes logic that Bryce and I talked about over the jam, but there was a misunderstanding.  So I added it here.

It also does a bit of an odd thing, appending past the end of the descriptor array, these values will not be reference-able, however, they are here, so that that can be referenced by sandbox tools.