### PR TITLE
Fix various warnings

### DIFF
--- a/components/hdw-usb/hdw-usb.c
+++ b/components/hdw-usb/hdw-usb.c
@@ -84,7 +84,7 @@ static const uint8_t hid_report_descriptor[] = {TUD_HID_REPORT_DESC_GAMEPAD_SWAD
 /**
  * @brief String descriptor
  */
-static char* hid_string_descriptor[7] = {
+static const char* hid_string_descriptor[7] = {
     // array of pointer to string descriptors
     (char[]){0x09, 0x04},   // 0: is supported language is English (0x0409)
     "Magfest",              // 1: Manufacturer

--- a/emulator/idf-inc/tinyusb.h
+++ b/emulator/idf-inc/tinyusb.h
@@ -89,10 +89,10 @@ typedef struct
         const tusb_desc_device_t* descriptor
             __attribute__((deprecated)); /*!< Alias to `device_descriptor` for backward compatibility */
     };
-    char** string_descriptor;    /*!< Pointer to array of string descriptors. If set to NULL, TinyUSB device will use
-                                        a default string descriptors whose values are set in Kconfig */
-    int string_descriptor_count; /*!< Number of descriptors in above array */
-    bool external_phy;           /*!< Should USB use an external PHY */
+    const char** string_descriptor; /*!< Pointer to array of string descriptors. If set to NULL, TinyUSB device will use
+                                       a default string descriptors whose values are set in Kconfig */
+    int string_descriptor_count;    /*!< Number of descriptors in above array */
+    bool external_phy;              /*!< Should USB use an external PHY */
     const uint8_t*
         configuration_descriptor; /*!< Pointer to a configuration descriptor. If set to NULL, TinyUSB device will use a
                                      default configuration descriptor whose values are set in Kconfig */

--- a/main/asset_loaders/common/heatshrink_encoder.c
+++ b/main/asset_loaders/common/heatshrink_encoder.c
@@ -132,7 +132,7 @@ void heatshrink_encoder_reset(heatshrink_encoder* hse)
 #endif
 }
 
-HSE_sink_res heatshrink_encoder_sink(heatshrink_encoder* hse, uint8_t* in_buf, size_t size, size_t* input_size)
+HSE_sink_res heatshrink_encoder_sink(heatshrink_encoder* hse, const uint8_t* in_buf, size_t size, size_t* input_size)
 {
     if ((hse == NULL) || (in_buf == NULL) || (input_size == NULL))
     {
@@ -239,6 +239,7 @@ HSE_poll_res heatshrink_encoder_poll(heatshrink_encoder* hse, uint8_t* out_buf, 
                 break;
             case HSES_FLUSH_BITS:
                 hse->state = st_flush_bit_buffer(hse, &oi);
+                // Fall through
             case HSES_DONE:
                 return HSER_POLL_EMPTY;
             default:

--- a/main/asset_loaders/common/heatshrink_encoder.h
+++ b/main/asset_loaders/common/heatshrink_encoder.h
@@ -92,7 +92,7 @@ void heatshrink_encoder_reset(heatshrink_encoder* hse);
 /* Sink up to SIZE bytes from IN_BUF into the encoder.
  * INPUT_SIZE is set to the number of bytes actually sunk (in case a
  * buffer was filled.). */
-HSE_sink_res heatshrink_encoder_sink(heatshrink_encoder* hse, uint8_t* in_buf, size_t size, size_t* input_size);
+HSE_sink_res heatshrink_encoder_sink(heatshrink_encoder* hse, const uint8_t* in_buf, size_t size, size_t* input_size);
 
 /* Poll for output from the encoder, copying at most OUT_BUF_SIZE bytes into
  * OUT_BUF (setting *OUTPUT_SIZE to the actual amount copied). */

--- a/main/display/shapes.c
+++ b/main/display/shapes.c
@@ -16,8 +16,12 @@
 #define FIXEDPOINT   16
 #define FIXEDPOINTD2 15
 
-#undef SETUP_FOR_TURBO
-#define SETUP_FOR_TURBO() register uint32_t dispPx = (uint32_t)dispPxL;
+#if defined(__XTENSA__)
+    /* SETUP_FOR_TURBO() is defined in hdw-tft.h, but it is overridden here because accessing dispPxL is faster than
+     * getPxTftFramebuffer() */
+    #undef SETUP_FOR_TURBO
+    #define SETUP_FOR_TURBO() register uint32_t dispPx = (uint32_t)dispPxL;
+#endif
 
 //==============================================================================
 // Function Prototypes
@@ -48,8 +52,11 @@ static void drawCubicBezierInner(int x0, int y0, int x1, int y1, int x2, int y2,
 // Variables
 //==============================================================================
 
-/// @brief Static local pointer to the framebuffer. Using this, for some reason, is faster than normal draw calls.
-static uint32_t dispPxL = NULL;
+#if defined(__XTENSA__)
+/* @brief Static local pointer to the framebuffer. Using this, for some reason, is faster than normal draw calls. This
+ * is only set for __XTENSA__ because it jams a pointer into a 32 bit variable */
+static uint32_t dispPxL = 0;
+#endif
 
 //==============================================================================
 // Functions
@@ -61,7 +68,9 @@ static uint32_t dispPxL = NULL;
  */
 void initShapes(void)
 {
-    dispPxL = getPxTftFramebuffer();
+#if defined(__XTENSA__)
+    dispPxL = (uint32_t)getPxTftFramebuffer();
+#endif
 }
 
 /**

--- a/main/modes/gamepad/gamepad.c
+++ b/main/modes/gamepad/gamepad.c
@@ -169,7 +169,7 @@ static const tusb_desc_device_t nsDescriptor = {
 };
 
 /// @brief PC string Descriptor
-static char* hid_string_descriptor[5] = {
+static const char* hid_string_descriptor[5] = {
     // array of pointer to string descriptors
     (char[]){0x09, 0x04},   // 0: is supported language is English (0x0409)
     "Magfest",              // 1: Manufacturer

--- a/main/modes/mfpaint/paint_browser.c
+++ b/main/modes/mfpaint/paint_browser.c
@@ -143,10 +143,7 @@ void setupImageBrowser(imageBrowser_t* browser, const font_t* font, const char* 
         nvs_entry_info_t* imageInfos = calloc(numInfos, sizeof(nvs_entry_info_t));
         if (readNamespaceNvsEntryInfos(namespace, NULL, imageInfos, NULL))
         {
-            if (numInfos > 0)
-            {
-                qsort(imageInfos, numInfos, sizeof(nvs_entry_info_t), compareEntryInfoAlpha);
-            }
+            qsort(imageInfos, numInfos, sizeof(nvs_entry_info_t), compareEntryInfoAlpha);
 
             for (uint32_t i = 0; i < numInfos; ++i)
             {

--- a/main/modes/mfpaint/paint_canvas.c
+++ b/main/modes/mfpaint/paint_canvas.c
@@ -200,14 +200,14 @@ static size_t _paintSerialize(uint8_t* dest, const paintCanvas_t* canvas, const 
     // build the chunk
     for (uint16_t n = 0; n < count; n++)
     {
-        if (offset * 2 + (n * 2) >= (wsg ? (wsg->w * wsg->h) : (canvas->w * canvas->h)))
-        {
-            // If we've just stored the last pixel, return false to indicate that we're done
-            return n;
-        }
-
         if (canvas)
         {
+            if (offset * 2 + (n * 2) >= (wsg ? (wsg->w * wsg->h) : (canvas->w * canvas->h)))
+            {
+                // If we've just stored the last pixel, return false to indicate that we're done
+                return n;
+            }
+
             // calculate the real coordinates given the pixel indices
             // (we store 2 pixels in each byte)
             // that's 100% more pixel, per pixel!

--- a/main/modes/mfpaint/paint_gallery.c
+++ b/main/modes/mfpaint/paint_gallery.c
@@ -34,7 +34,6 @@ static const uint16_t transitionTimeMap[] = {
 #define GALLERY_INFO_TIME     3000000
 #define GALLERY_INFO_Y_MARGIN 18
 #define GALLERY_INFO_X_MARGIN 24
-#define GALLERY_ARROW_MARGIN  6
 
 paintGallery_t* paintGallery;
 
@@ -64,7 +63,7 @@ void paintGallerySetup(bool screensaver)
         paintGallery->gallerySpeedIndex = DEFAULT_TRANSITION_INDEX;
     }
 
-    if (!readNvs32(viewStyleNvsKey, &paintGallery->browser.viewStyle))
+    if (!readNvs32(viewStyleNvsKey, (int32_t*)(&paintGallery->browser.viewStyle)))
     {
         paintGallery->browser.viewStyle = BROWSER_GALLERY;
     }
@@ -418,7 +417,7 @@ void paintGalleryModeButtonCb(buttonEvt_t* evt)
 
 void paintGalleryModePollTouch(void)
 {
-    int32_t centroid, intensity;
+    int32_t intensity;
 
     int32_t phi, r;
     if (getTouchJoystick(&phi, &r, &intensity))

--- a/main/modes/mfpaint/paint_share.c
+++ b/main/modes/mfpaint/paint_share.c
@@ -582,9 +582,9 @@ void paintRenderShareMode(int64_t elapsedUs)
         // Flash the pixel we're waiting for / last sent
         if (paintShare->dataOffset != 0 && paintShare->dataOffset * 2 < paintShare->canvas.w * paintShare->canvas.h)
         {
-            uint16_t x = (paintShare->dataOffset * 2) % paintShare->canvas.w;
-            uint16_t y = (paintShare->dataOffset * 2) / paintShare->canvas.w;
-            setPxScaled(x, y, ((paintShare->shareTime % 1000000) > 500000) ? c000 : c555, paintShare->canvas.x,
+            uint16_t x_s = (paintShare->dataOffset * 2) % paintShare->canvas.w;
+            uint16_t y_s = (paintShare->dataOffset * 2) / paintShare->canvas.w;
+            setPxScaled(x_s, y_s, ((paintShare->shareTime % 1000000) > 500000) ? c000 : c555, paintShare->canvas.x,
                         paintShare->canvas.y, paintShare->canvas.xScale, paintShare->canvas.yScale);
         }
     }

--- a/main/modes/timer/modeTimer.c
+++ b/main/modes/timer/modeTimer.c
@@ -18,7 +18,6 @@
 // Defines
 //==============================================================================
 
-#define HOURGLASS_FRAMES   12
 #define PAUSE_FLASH_SPEED  1000000
 #define PAUSE_FLASH_SHOW   600000
 #define EXPIRE_FLASH_SPEED 500000


### PR DESCRIPTION
Make USB descriptors const
Fix emu tinyusb.h to match actual
Make heatshrink_encoder_sink() ingest const data
Only do framebuffer tricks in shapes.c for __XTENSA__ Only qsort() non-empty arrays
Fix possible null pointer in _paintSerialize()
Remove unused variables
Un-shadow variables
Don't mix pointer types
Use correct declaration for qsort comparator

### Description

Fixed various warnings

### Test Instructions

Compile without warnings (emu, fw)
Run cppcheck & ignore alloca() warnings

### Ticket Links

n/a

### Readiness Checklist
- [x] I have run `make format` to format the changes
- [x] I have compiled the firmware and the changes have no warnings
- [x] I have compiled the emulator and the changes have no warnings
- [x] I have run `make cppcheck` and checked that `cppcheck_result.txt` has no warnings for the changes
- [x] I have added doxygen comments to any code used by more than one Swadge mode. This includes `/*! \file` comments with Design Philosophy, Usage, and Example sections for new headers.
- [x] I have run `make docs` and checked that `doxy_warnings.txt` has no warnings for the new code
