### PR TITLE
Magtroid game over

### DIFF
--- a/main/modes/ray/ray_death_screen.c
+++ b/main/modes/ray/ray_death_screen.c
@@ -9,25 +9,29 @@
 //==============================================================================
 
 static const char* const deathTexts[] = {
+    // Cheeky messages
     "GG no re",
     "Skill Issue",
     "Press F",
     "YOUR HEAD ASPLODE",
     "You may have died, but you are not safe from taxes",
-    "Pro Tip: Shoot the enemies until they die",
     "Your suit didn't disintegrate revealing a bikini-clad bird, you just died",
     "Should have ducked",
     "I guess the galaxy will never be at peace",
-    "Turns out main characters *can* die, who knew?",
     "Runtime error 0x00001337 SEGMENTATION FAULT nah just kidding you died",
     "Have you tried turning it off and then on again?",
-    "Try again, but do better",
-    "Remember when you used to give the controller to a friend to beat the hard levels? Yeah, good times...",
-    "Game Over. Insert two quarters to continue.",
+    "Remember when you used to give the controller to a friend to beat the hard levels? Good times...",
+    "Insert two quarters to continue",
     "One life remaining... Just kidding!",
-    "Would you like to purchase better armor for $5? Too bad, we don't pay to win!",
-    "You seem to be experiencing cognitive and / or coordination difficulties. Emergency medical services have been "
-    "alerted.",
+    "Would you like to purchase better armor for $5? Too bad, no pay to win here!",
+
+    // Actually helpful messages
+    "Remember to check your map with the PAUSE button!",
+    "You can lock onto enemies with the B button to strafe around their shots! DODGE!",
+    "Try exploring previous worlds and solving puzzles to find health and ammo upgrades!",
+    "Did you know that enemies have weaknesses to certain weapons?",
+    "Keys and doors are color- and shape-coded for your convenience.",
+    "The LEDs on the Swadge use radar technology to point to the nearest enemy.",
 };
 
 //==============================================================================

--- a/main/modes/ray/ray_death_screen.c
+++ b/main/modes/ray/ray_death_screen.c
@@ -26,7 +26,7 @@ static const char* const deathTexts[] = {
     "Game Over. Insert two quarters to continue.",
     "One life remaining... Just kidding!",
     "Would you like to purchase better armor for $5? Too bad, we don't pay to win!",
-    "You seem to be experiencing cognitive and/or coordination difficulties. Emergency medical services have been "
+    "You seem to be experiencing cognitive and / or coordination difficulties. Emergency medical services have been "
     "alerted.",
 };
 
@@ -80,17 +80,27 @@ void rayDeathScreenRender(ray_t* ray, uint32_t elapsedUs)
     // Fill dark red background
     fillDisplayArea(0, 0, TFT_WIDTH, TFT_HEIGHT, c100);
 
+    // Draw a title
+    const char* gameOverText = "Game Over";
+    int16_t tWidth           = textWidth(&ray->logbook, gameOverText);
+    int16_t goX              = (TFT_WIDTH - tWidth) / 2;
+    drawText(&ray->logbook, c542, gameOverText, goX, 0);
+    fillDisplayArea(goX, ray->logbook.height + 2, goX + tWidth, ray->logbook.height + 3, c542);
+
 #define DEATH_TEXT_MARGIN 25
 
+    int16_t messageMaxHeight = (TFT_HEIGHT - (ray->logbook.height + 3));
+
     // Measure the height of the wrapped text
-    uint16_t tHeight = textWordWrapHeight(&ray->logbook, ray->deathText, TFT_WIDTH - (DEATH_TEXT_MARGIN * 2),
-                                          TFT_HEIGHT - (DEATH_TEXT_MARGIN * 2));
+    uint16_t tHeight
+        = textWordWrapHeight(&ray->logbook, ray->deathText, TFT_WIDTH - (DEATH_TEXT_MARGIN * 2), messageMaxHeight);
 
     // Set the offsets
     int16_t xOff = DEATH_TEXT_MARGIN;
-    int16_t yOff = (TFT_HEIGHT - tHeight) / 2;
+    int16_t yOff = ((messageMaxHeight - tHeight) / 2) + (ray->logbook.height + 3);
 
-    drawTextWordWrap(&ray->logbook, c542, ray->deathText, &xOff, &yOff, TFT_WIDTH - xOff, TFT_HEIGHT - yOff);
+    // Draw the message
+    drawTextWordWrap(&ray->logbook, c542, ray->deathText, &xOff, &yOff, TFT_WIDTH - xOff, TFT_HEIGHT);
 
     // Blink an arrow to show there's more dialog
     if (ray->blink && 0 == ray->btnLockoutUs)

--- a/main/modes/ray/ray_pause.c
+++ b/main/modes/ray/ray_pause.c
@@ -178,7 +178,7 @@ void rayPauseCheckButtons(ray_t* ray)
 void rayPauseRender(ray_t* ray, uint32_t elapsedUs)
 {
     // Clear to black first
-    clearPxTft();
+    fillDisplayArea(0, 0, TFT_WIDTH, TFT_HEIGHT, c000);
 
     // Render based on the displayed screen
     switch (ray->pauseScreen)

--- a/main/modes/ray/ray_renderer.c
+++ b/main/modes/ray/ray_renderer.c
@@ -687,9 +687,6 @@ rayObjCommon_t* castSprites(ray_t* ray, rayEnemy_t** closestEnemy)
     // Setup to draw
     SETUP_FOR_TURBO();
 
-    // Boolean if the colors should be drawn inverted
-    bool isXray = (LO_XRAY == ray->p.loadout);
-
     // Put an array on the stack to sort all sprites
     objDist_t allObjs[MAX_RAY_BULLETS + ray->scenery.length + ray->enemies.length + ray->items.length];
     int32_t allObjsIdx = 0;
@@ -785,10 +782,17 @@ rayObjCommon_t* castSprites(ray_t* ray, rayEnemy_t** closestEnemy)
         // Make sure this object slot is occupied
         if (-1 != obj->id)
         {
+            // Boolean if the colors should be drawn inverted
+            bool isXray = (LO_XRAY == ray->p.loadout);
+
             bool isEnemy = CELL_IS_TYPE(obj->type, OBJ | ENEMY);
             if (isEnemy)
             {
                 *closestEnemy = (rayEnemy_t*)obj;
+                if (OBJ_ENEMY_BOSS == obj->type)
+                {
+                    isXray = false;
+                }
             }
 
             // Get WSG dimensions for convenience


### PR DESCRIPTION
### Description

* Draw "Game Over" on the game over screen
* Updated game over text
* Don't invert the boss's colors when using X-Ray visor
* Don't use `clearPxTft()` (may fix phantom text, maybe not?)

### Test Instructions

Played the game, died

### Ticket Links

n/a

### Readiness Checklist
- [x] I have run `make format` to format the changes
- [x] I have compiled the firmware and the changes have no warnings
- [x] I have compiled the emulator and the changes have no warnings
- [x] I have run `make cppcheck` and checked that `cppcheck_result.txt` has no warnings for the changes
- [x] I have added doxygen comments to any code used by more than one Swadge mode. This includes `/*! \file` comments with Design Philosophy, Usage, and Example sections for new headers.
- [x] I have run `make docs` and checked that `doxy_warnings.txt` has no warnings for the new code