### PR TITLE
Lumber Jacks: Led Flicker Fix

### DIFF
--- a/main/modes/lumberjack/lumberjack.c
+++ b/main/modes/lumberjack/lumberjack.c
@@ -53,7 +53,7 @@ static const char lumberjackExit[]         = "Exit";
 
 static char lumberjackRedCharacter[]     = "Character: Red";
 static char lumberjackGreenCharacter[]   = "Character: Green";
-static char lumberjackSpecialCharacter[] = "Character: Guy";
+static char lumberjackSpecialCharacter[] = "Character: Petak";
 static char lumberjackChoCharacter[]     = "Character: Cho";
 
 static const char lumberjackMenuSinglePlayer[] = "Single Player";
@@ -287,7 +287,7 @@ static void lumberjackMainLoop(int64_t elapsedUs)
             lumberjackMenuLoop(elapsedUs);
             for (int ledIdx = 0; ledIdx < ARRAY_SIZE(lumberjack->menuLogbookRenderer->leds); ledIdx++)
             {
-                lumberjack->menuLogbookRenderer->ledTimers[ledIdx].periodUs = 1;
+                lumberjack->menuLogbookRenderer->ledTimers[ledIdx].periodUs = 1000000;
                 lumberjack->menuLogbookRenderer->ledTimers[ledIdx].timerUs  = 0;
                 lumberjack->menuLogbookRenderer->ledTimers[ledIdx].brightness
                     = 255; // lumberjack->menuLogbookRenderer->ledTimers[ledIdx].maxBrightness;


### PR DESCRIPTION
One line fix!

### Description
Fixed flickering LEDs when you select Red

### Test Instructions
On hardware go to the Lumber Jacks menu and toggle between Green & Red 

### Ticket Links
https://github.com/AEFeinstein/Swadge-IDF-5.0/issues/178

### Readiness Checklist
- [ ] I have run `make format` to format the changes
- [x] I have compiled the firmware and the changes have no warnings
- [x] I have compiled the emulator and the changes have no warnings
- [x] I have run `make cppcheck` and checked that `cppcheck_result.txt` has no warnings for the changes
- [ ] I have added doxygen comments to any code used by more than one Swadge mode. This includes `/*! \file` comments with Design Philosophy, Usage, and Example sections for new headers.
- [x] I have run `make docs` and checked that `doxy_warnings.txt` has no warnings for the new code
