### PR TITLE
Fix infinite sustain on some instruments and unchangeable MMX Organ release time

### DIFF
--- a/main/midi/midiData.c
+++ b/main/midi/midiData.c
@@ -287,8 +287,6 @@ const midiTimbre_t donutDrumkitTimbre = {
     .name = "Donut Swadge Drums",
 };
 
-// convert original sample numbers to account for sample rate changing
-#define SAMPLE_NUM_CONV(count, origRate, targetRate) ((count) * (targetRate) / (origRate))
 #define SECONDS_CONV(whole, microseconds)            ((whole) * 16384 + ((int64_t)microseconds) * 16384 / 1000000)
 // #define PITCH_HZ(whole, thousandths)                 ((whole) << 16 | ((thousandths) * (1 << 16) / 1000))
 


### PR DESCRIPTION
## Description

Fixes some rollover or something causing infinite sustain on several instruments. Also fixes that the organ was still using only a velocity-dependent release time and ignored the regular one.

## Test Instructions

Tested by playing with the bell synth and the organ instruments and seeing if they stay stuck forever, and that they respond to CC# 72 noticeably.

## Ticket Links

<!--- Link any tickets that are completed in this pull request. -->

## Readiness Checklist

### Code Quality

- [x] I have run `make format` to format the changes
- [x] I have compiled the firmware and the changes have no warnings
- [x] I have compiled the emulator and the changes have no warnings
- [x] I have run `make cppcheck` and checked that `cppcheck_result.txt` has no warnings for the changes
- [x] I have added doxygen comments to any code used by more than one Swadge mode. This includes `/*! \file` comments with Design Philosophy, Usage, and Example sections for new headers.
- [x] I have run `make docs` and checked that `doxy_warnings.txt` has no warnings for the new code

### Feature Usage

<!--- These aren't mandatory, especially for non-game tickets, but are strongly encouraged -->

- [ ] As much hardware input is used as reasonable (buttons, touchpad, IMU, microphone)
- [ ] As much hardware output is used as reasonable (screen, LEDs, speaker)
- [ ] [Trophy](https://adam.feinste.in/Super-2024-Swadge-FW/trophy_8h.html) support is integrated
- [ ] [SwadgePass](https://adam.feinste.in/Super-2024-Swadge-FW/swadgePass_8h.html) support is integrated
