### PR TITLE
Added two methods of backing out of Trophy Case

### DIFF
--- a/main/modes/system/trophyCase/trophyCase.c
+++ b/main/modes/system/trophyCase/trophyCase.c
@@ -26,6 +26,7 @@ const char tCaseModeName[]           = "Trophy Case";
 static const char* const menuItems[] = {"Scores", "Mode: "};
 static const char scoreStr[]         = "Scores";
 static const char individualStr[]    = "Individual modes";
+static const char exitStr[]          = "Exit Case";
 
 static const char* const caseOptions[] = {"All", "Unlocked", "Locked"};
 static const int32_t caseSettings[]    = {TROPHY_DISPLAY_ALL, TROPHY_DISPLAY_UNLOCKED, TROPHY_DISPLAY_LOCKED};
@@ -131,6 +132,7 @@ static void enterTCase(void)
             addSingleItemToMenu(tc->menu, allSwadgeModes[idx]->modeName);
         }
     }
+    addSingleItemToMenu(tc->menu, exitStr);
 }
 
 static void exitTCase(void)
@@ -198,6 +200,10 @@ static void runTCase(int64_t elapsedUs)
         {
             while (checkButtonQueueWrapper(&evt))
             {
+                if (evt.down && evt.button & PB_B)
+                {
+                    switchToSwadgeMode(&mainMenuMode);
+                }
                 tc->menu = menuButton(tc->menu, evt);
             }
             drawMenuMega(tc->menu, tc->rnd, elapsedUs);
@@ -224,6 +230,10 @@ static bool tCaseMenuCb(const char* label, bool selected, uint32_t settingVal)
         {
             tc->state = TC_STATS;
             tc->idx   = 0;
+        }
+        else if (label == exitStr)
+        {
+            switchToSwadgeMode(&mainMenuMode);
         }
     }
     if (label == menuItems[1])


### PR DESCRIPTION
## Description

Added two methods of backing out of Trophy Case:
- B button at the top of the menu structure
- Exit button in menu

## Test Instructions

Emulator, load mode and press B or select the exit option

## Ticket Links

#507 

## Readiness Checklist

### Code Quality

- [x] I have run `make format` to format the changes
- [x] I have compiled the firmware and the changes have no warnings
- [x] I have compiled the emulator and the changes have no warnings
- [x] I have run `make cppcheck` and checked that `cppcheck_result.txt` has no warnings for the changes
- [ ] I have added doxygen comments to any code used by more than one Swadge mode. This includes `/*! \file` comments with Design Philosophy, Usage, and Example sections for new headers.
- [ ] I have run `make docs` and checked that `doxy_warnings.txt` has no warnings for the new code
