### PR TITLE
Dice mode tweaks

### DIFF
--- a/main/modes/utilities/dice/mode_diceroller.c
+++ b/main/modes/utilities/dice/mode_diceroller.c
@@ -269,7 +269,6 @@ void diceEnterMode(void)
  */
 void diceExitMode(void)
 {
-    freeFont(diceRoller->ibm_vga8);
     freeWsg(&diceRoller->woodTexture);
     freeWsg(&diceRoller->cursor);
     freeWsg(&diceRoller->corner);


### PR DESCRIPTION
## Description

- Was loading a second instance of IBM_VGA8 font, use system pre-loaded font instead
- A, B and Start all rolled dice. Now, only A rolls, B returns to menu, and Start does nothing
- In the history, the numbers are aligned to the colon in the center of the text for better visual alignment

## Test Instructions

Dice mode, try 6d100k6, 6d12k6, and 1d4k1 to ensure they are all aligned.

## Ticket Links

None

## Readiness Checklist

### Code Quality

- [x] I have run `make format` to format the changes
- [x] I have compiled the firmware and the changes have no warnings
- [x] I have compiled the emulator and the changes have no warnings
- [x] I have run `make cppcheck` and checked that `cppcheck_result.txt` has no warnings for the changes
- [ ] I have added doxygen comments to any code used by more than one Swadge mode. This includes `/*! \file` comments with Design Philosophy, Usage, and Example sections for new headers.
- [ ] I have run `make docs` and checked that `doxy_warnings.txt` has no warnings for the new code
