### PR TITLE
#516 Add Eye LED bars to Colorchord

### DIFF
--- a/main/modes/music/colorchord/colorchord.c
+++ b/main/modes/music/colorchord/colorchord.c
@@ -19,6 +19,9 @@
 #define TEXT_Y      10
 #define TEXT_MARGIN 20
 
+#define EYE_FPS    20
+#define EYE_FPS_US (1000000 / EYE_FPS)
+
 //==============================================================================
 // Enums
 //==============================================================================
@@ -47,7 +50,6 @@ void colorchordButtonCb(buttonEvt_t* evt);
 
 typedef struct
 {
-    font_t ibm_vga8;
     dft32_data dd;
     embeddedNf_data end;
     embeddedOut_data eod;
@@ -57,6 +59,11 @@ typedef struct
     uint16_t* sampleHist;
     uint16_t sampleHistHead;
     uint16_t sampleHistCount;
+
+    // Variables for LED eyes
+    int32_t eyeTimer;
+    uint16_t binAvgHist[EYE_FPS];
+    int32_t bahIdx;
 } colorchord_t;
 
 //==============================================================================
@@ -101,9 +108,6 @@ void colorchordEnterMode(void)
         = (uint16_t*)heap_caps_calloc(colorchord->sampleHistCount, sizeof(uint16_t), MALLOC_CAP_8BIT);
     colorchord->sampleHistHead = 0;
 
-    // Load a font
-    loadFont(IBM_VGA_8_FONT, &colorchord->ibm_vga8, false);
-
     // Init CC
     InitColorChord(&colorchord->end, &colorchord->dd);
     colorchord->maxValue = 1;
@@ -118,7 +122,6 @@ void colorchordExitMode(void)
     {
         heap_caps_free(colorchord->sampleHist);
     }
-    freeFont(&colorchord->ibm_vga8);
     heap_caps_free(colorchord);
 }
 
@@ -182,7 +185,7 @@ void colorchordMainLoop(int64_t elapsedUs __attribute__((unused)))
     for (uint16_t i = 0; i < FIX_BINS; i++)
     {
         uint8_t height
-            = ((TFT_HEIGHT - colorchord->ibm_vga8.height - 2) * colorchord->end.fuzzed_bins[i]) / colorchord->maxValue;
+            = ((TFT_HEIGHT - getSysFont()->height - 2) * colorchord->end.fuzzed_bins[i]) / colorchord->maxValue;
 
         paletteColor_t color = RGBtoPalette(
             ECCtoHEX(((i << SEMI_BITS_PER_BIN) + colorchord->eod.RootNoteOffset) % NOTE_RANGE, 255, 255));
@@ -204,25 +207,26 @@ void colorchordMainLoop(int64_t elapsedUs __attribute__((unused)))
     char text[16] = {0};
 
     // Draw gain indicator
-    snprintf(text, sizeof(text), "Gain: %" PRIu8, getMicGainSetting());
-    drawText(&colorchord->ibm_vga8, c555, text, TEXT_MARGIN, TEXT_Y);
+    uint8_t gain = getMicGainSetting();
+    snprintf(text, sizeof(text), "Gain: %" PRIu8, gain);
+    drawText(getSysFont(), c555, text, TEXT_MARGIN, TEXT_Y);
 
     // Underline it if selected
     if (CC_OPT_GAIN == colorchord->optSel)
     {
-        int16_t lineY = 10 + colorchord->ibm_vga8.height + 2;
-        drawLine(TEXT_MARGIN, lineY, TEXT_MARGIN + textWidth(&colorchord->ibm_vga8, text) - 1, lineY, c555, 0);
+        int16_t lineY = 10 + getSysFont()->height + 2;
+        drawLine(TEXT_MARGIN, lineY, TEXT_MARGIN + textWidth(getSysFont(), text) - 1, lineY, c555, 0);
     }
 
     // Draw LED brightness indicator
     snprintf(text, sizeof(text), "LED: %" PRIu8, getLedBrightnessSetting());
-    int16_t tWidth = textWidth(&colorchord->ibm_vga8, text);
-    drawText(&colorchord->ibm_vga8, c555, text, (TFT_WIDTH - tWidth) / 2, TEXT_Y);
+    int16_t tWidth = textWidth(getSysFont(), text);
+    drawText(getSysFont(), c555, text, (TFT_WIDTH - tWidth) / 2, TEXT_Y);
 
     // Underline it if selected
     if (CC_OPT_LED_BRIGHT == colorchord->optSel)
     {
-        int16_t lineY = TEXT_Y + colorchord->ibm_vga8.height + 2;
+        int16_t lineY = TEXT_Y + getSysFont()->height + 2;
         drawLine((TFT_WIDTH - tWidth) / 2, lineY, (TFT_WIDTH - tWidth) / 2 + tWidth - 1, lineY, c555, 0);
     }
 
@@ -242,21 +246,80 @@ void colorchordMainLoop(int64_t elapsedUs __attribute__((unused)))
             break;
         }
     }
-    int16_t textX = TFT_WIDTH - TEXT_MARGIN - textWidth(&colorchord->ibm_vga8, text);
-    drawText(&colorchord->ibm_vga8, c555, text, textX, TEXT_Y);
+    int16_t textX = TFT_WIDTH - TEXT_MARGIN - textWidth(getSysFont(), text);
+    drawText(getSysFont(), c555, text, textX, TEXT_Y);
 
     // Underline it if selected
     if (CC_OPT_LED_MODE == colorchord->optSel)
     {
-        int16_t lineY = TEXT_Y + colorchord->ibm_vga8.height + 2;
-        drawLine(textX, lineY, textX + textWidth(&colorchord->ibm_vga8, text) - 1, lineY, c555, 0);
+        int16_t lineY = TEXT_Y + getSysFont()->height + 2;
+        drawLine(textX, lineY, textX + textWidth(getSysFont(), text) - 1, lineY, c555, 0);
     }
 
     // Draw reminder text
     const char exitText[] = "Hold Menu to Exit";
-    int16_t exitWidth     = textWidth(&colorchord->ibm_vga8, exitText);
-    drawText(&colorchord->ibm_vga8, c555, exitText, (TFT_WIDTH - exitWidth) / 2,
-             TFT_HEIGHT - colorchord->ibm_vga8.height - TEXT_Y);
+    int16_t exitWidth     = textWidth(getSysFont(), exitText);
+    drawText(getSysFont(), c555, exitText, (TFT_WIDTH - exitWidth) / 2, TFT_HEIGHT - getSysFont()->height - TEXT_Y);
+
+    RUN_TIMER_EVERY(colorchord->eyeTimer, EYE_FPS_US, elapsedUs, {
+
+#define LED_W 12
+#define LED_H 6
+        // There are 24 bins and 12 columns, so average every two bins into a column
+        uint16_t binAvgs[LED_W] = {0};
+        uint16_t maxBinAvg      = 0;
+        for (int32_t bIdx = 0; bIdx < ARRAY_SIZE(binAvgs); bIdx++)
+        {
+            binAvgs[bIdx] = (colorchord->end.folded_bins[2 * bIdx] + colorchord->end.folded_bins[(2 * bIdx) + 1]) / 2;
+
+            // Keep track of the largest average
+            if (binAvgs[bIdx] > maxBinAvg)
+            {
+                maxBinAvg = binAvgs[bIdx];
+            }
+        }
+
+        // Add the largest average to the history
+        colorchord->binAvgHist[colorchord->bahIdx] = maxBinAvg;
+        colorchord->bahIdx                         = (colorchord->bahIdx + 1) % ARRAY_SIZE(colorchord->binAvgHist);
+
+        // Find the largest average in the moving history
+        for (int32_t bIdx = 0; bIdx < ARRAY_SIZE(colorchord->binAvgHist); bIdx++)
+        {
+            if (colorchord->binAvgHist[bIdx] > maxBinAvg)
+            {
+                maxBinAvg = colorchord->binAvgHist[bIdx];
+            }
+        }
+
+        // Bring up the average to a floor, derived from mic gain.
+        // This prevents visualizing noise on the LEDs
+        maxBinAvg = MAX(87 * gain, maxBinAvg);
+
+        // Normalize the values to LED_H
+        if (maxBinAvg)
+        {
+            for (int32_t bIdx = 0; bIdx < ARRAY_SIZE(binAvgs); bIdx++)
+            {
+                binAvgs[bIdx] = ((1 + LED_H) * binAvgs[bIdx]) / maxBinAvg;
+            }
+        }
+
+        // Draw bars to the eye LEDs
+        uint8_t bitmap[LED_H][LED_W] = {0};
+        for (int x = 0; x < LED_W; x++)
+        {
+            for (int y = 0; y < LED_H; y++)
+            {
+                if (y > (LED_H - binAvgs[x]))
+                {
+                    bitmap[LED_H - 1 - y][x] = 0xFF;
+                }
+            }
+        }
+        ch32v003WriteBitmap(0, bitmap);
+        ch32v003SelectBitmap(0);
+    });
 }
 
 /**


### PR DESCRIPTION
## Description

Added Colorchord-derived visualization to eye LEDs

## Test Instructions

Run Colorchord. Hum at it. Adjust the gain and hum again.

## Ticket Links

#516 

## Readiness Checklist

### Code Quality

- [x] I have run `make format` to format the changes
- [x] I have compiled the firmware and the changes have no warnings
- [x] I have compiled the emulator and the changes have no warnings
- [ ] I have run `make cppcheck` and checked that `cppcheck_result.txt` has no warnings for the changes
- [x] I have added doxygen comments to any code used by more than one Swadge mode. This includes `/*! \file` comments with Design Philosophy, Usage, and Example sections for new headers.
- [x] I have run `make docs` and checked that `doxy_warnings.txt` has no warnings for the new code

### Feature Usage

<!--- These aren't mandatory, especially for non-game tickets, but are strongly encouraged -->

- [x] As much hardware input is used as reasonable (buttons, touchpad, IMU, microphone)
- [x] As much hardware output is used as reasonable (screen, LEDs, speaker)
- [ ] [Trophy](https://adam.feinste.in/Super-2024-Swadge-FW/trophy_8h.html) support is integrated
- [ ] [SwadgePass](https://adam.feinste.in/Super-2024-Swadge-FW/swadgePass_8h.html) support is integrated