### PR TITLE
Set vibraphone release time to 0

### DIFF
--- a/main/midi/midiData.c
+++ b/main/midi/midiData.c
@@ -307,7 +307,7 @@ const midiTimbre_t mmx011Vibraphone = {
     .envelope = {
         .attackTime = SECONDS_CONV(0, 1000), // 1ms
         // .releaseTime = SECONDS_CONV(2, 70530), // 2.070530s
-        .releaseTime = SECONDS_CONV(0, 675300), // ~2.070530s / 4
+        .releaseTime = 0,
         .sustainVol = 127,
     },
 };


### PR DESCRIPTION
## Description

Sets release on the vibraphone to 0.

## Test Instructions

Listen to a song with vibraphone, see that notes stop sounding immediately after release without a fadeout.

## Ticket Links

<!--- Link any tickets that are completed in this pull request. -->

## Readiness Checklist

### Code Quality

- [x] I have run `make format` to format the changes
- [x] I have compiled the firmware and the changes have no warnings
- [x] I have compiled the emulator and the changes have no warnings
- [ ] I have run `make cppcheck` and checked that `cppcheck_result.txt` has no warnings for the changes
- [ ] I have added doxygen comments to any code used by more than one Swadge mode. This includes `/*! \file` comments with Design Philosophy, Usage, and Example sections for new headers.
- [ ] I have run `make docs` and checked that `doxy_warnings.txt` has no warnings for the new code

### Feature Usage

<!--- These aren't mandatory, especially for non-game tickets, but are strongly encouraged -->

- [ ] As much hardware input is used as reasonable (buttons, touchpad, IMU, microphone)
- [ ] As much hardware output is used as reasonable (screen, LEDs, speaker)
- [ ] [Trophy](https://adam.feinste.in/Super-2024-Swadge-FW/trophy_8h.html) support is integrated
- [ ] [SwadgePass](https://adam.feinste.in/Super-2024-Swadge-FW/swadgePass_8h.html) support is integrated
