### PR TITLE
Persist LED dance and speed

### DIFF
--- a/main/modes/utilities/dance/dance.c
+++ b/main/modes/utilities/dance/dance.c
@@ -34,12 +34,11 @@
 #include "dance_Flashlight.h"
 #include "dance_None.h"
 #include "dance_RandomDance.h"
+#include "portableDance.h"
 
 //==============================================================================
 // Defines
 //==============================================================================
-
-#define DANCE_SPEED_MULT 8
 
 // Sleep the TFT after 5s
 #define TFT_TIMEOUT_US 5000000
@@ -50,10 +49,8 @@
 
 typedef struct
 {
-    uint32_t danceIdx;
-    uint32_t danceSpeed;
+    portableDance_t* dance;
 
-    bool resetDance;
     bool blankScreen;
 
     uint32_t buttonPressedTimer;
@@ -107,6 +104,7 @@ static const int32_t speedVals[] = {
     4,  // 2x
     2,  // 4x
 };
+static const char nvsNs[] = "light_dances";
 
 const ledDance_t ledDances[] = {
     {.func = danceComet, .arg = RGB_2_ARG(0, 0, 0), .name = "Comet RGB"},
@@ -178,10 +176,8 @@ void danceEnterMode(void)
 
     danceState = heap_caps_calloc(1, sizeof(danceMode_t), MALLOC_CAP_8BIT);
 
-    danceState->danceIdx   = 0;
-    danceState->danceSpeed = DANCE_SPEED_MULT;
+    danceState->dance = initPortableDance(nvsNs);
 
-    danceState->resetDance  = true;
     danceState->blankScreen = false;
 
     danceState->buttonPressedTimer = 0;
@@ -216,7 +212,7 @@ void danceEnterMode(void)
         .max = ARRAY_SIZE(ledDances) - 1,
     };
     addSettingsOptionsItemToMenu(danceState->menu, NULL, danceState->danceNames, danceState->danceVals,
-                                 ARRAY_SIZE(ledDances), &danceParam, 0);
+                                 ARRAY_SIZE(ledDances), &danceParam, danceState->dance->danceIndex);
 
     // Add brightness to the menu
     addSettingsItemToMenu(danceState->menu, str_brightness, getLedBrightnessSettingBounds(), getLedBrightnessSetting());
@@ -227,7 +223,7 @@ void danceEnterMode(void)
         .max = speedVals[ARRAY_SIZE(speedVals) - 1],
     };
     addSettingsOptionsItemToMenu(danceState->menu, str_speed, speedLabels, speedVals, ARRAY_SIZE(speedVals),
-                                 &speedParam, speedVals[5]);
+                                 &speedParam, danceState->dance->speed);
 
     // Add exit to the menu
     addSingleItemToMenu(danceState->menu, str_exit);
@@ -253,6 +249,8 @@ void danceExitMode(void)
     deinitMenu(danceState->menu);
 
     deinitSwadgePassReceiver();
+
+    freePortableDance(danceState->dance);
 
     heap_caps_free(danceState->danceNames);
     heap_caps_free(danceState->danceVals);
@@ -284,9 +282,7 @@ void danceMainLoop(int64_t elapsedUs)
     }
 
     // Light the LEDs!
-    ledDances[danceState->danceIdx].func(elapsedUs * DANCE_SPEED_MULT / danceState->danceSpeed,
-                                         ledDances[danceState->danceIdx].arg, danceState->resetDance);
-    danceState->resetDance = false;
+    portableDanceMainLoop(danceState->dance, elapsedUs);
 
     // If the screen is blank
     if (danceState->blankScreen)
@@ -386,14 +382,13 @@ bool danceMenuCb(const char* label, bool selected, uint32_t value)
     }
     else if (str_speed == label)
     {
-        danceState->danceSpeed = value;
+        portableDanceSetSpeed(danceState->dance, (int32_t)value);
     }
     else if (NULL == label) // Dance names are label-less
     {
-        if (danceState->danceIdx != value)
+        if (danceState->dance->danceIndex != value)
         {
-            danceState->danceIdx   = value;
-            danceState->resetDance = true;
+            portableDanceSetByIndex(danceState->dance, value);
         }
     }
     return false;

--- a/main/modes/utilities/dance/portableDance.c
+++ b/main/modes/utilities/dance/portableDance.c
@@ -11,16 +11,23 @@
 void portableDanceLoadSetting(portableDance_t* dance);
 
 //==============================================================================
+// Const Variables
+//==============================================================================
+
+static const char nvsKeyDanceIndex[] = "dance_index";
+static const char nvsKeyDanceSpeed[] = "dance_speed";
+
+//==============================================================================
 // Functions
 //==============================================================================
 
 /**
  * @brief Returns a pointer to a portableDance_t.
  *
- * @param nvsKey The key where the dance index will be loaded and saved, if not NULL
+ * @param nvsNs The namespace where the dance index and speed will be loaded and saved, if not NULL
  * @return A pointer to a new portableDance_t
  */
-portableDance_t* initPortableDance(const char* nvsKey)
+portableDance_t* initPortableDance(const char* nvsNs)
 {
     portableDance_t* dance = heap_caps_calloc(1, sizeof(portableDance_t), MALLOC_CAP_8BIT);
     dance->dances          = heap_caps_calloc(1, sizeof(ledDanceOpt_t) * getNumDances(), MALLOC_CAP_8BIT);
@@ -31,10 +38,11 @@ portableDance_t* initPortableDance(const char* nvsKey)
     }
 
     dance->resetDance = true;
+    dance->speed      = DANCE_SPEED_MULT;
 
-    if (nvsKey != NULL)
+    if (nvsNs != NULL)
     {
-        dance->nvsKey = nvsKey;
+        dance->nvsNs = nvsNs;
         portableDanceLoadSetting(dance);
     }
 
@@ -66,8 +74,8 @@ void freePortableDance(portableDance_t* dance)
  */
 void portableDanceMainLoop(portableDance_t* dance, int64_t elapsedUs)
 {
-    dance->dances[dance->danceIndex].dance->func((int32_t)elapsedUs, dance->dances[dance->danceIndex].dance->arg,
-                                                 dance->resetDance);
+    dance->dances[dance->danceIndex].dance->func((int32_t)elapsedUs * DANCE_SPEED_MULT / dance->speed,
+                                                 dance->dances[dance->danceIndex].dance->arg, dance->resetDance);
     dance->resetDance = false;
 }
 
@@ -79,9 +87,9 @@ void portableDanceMainLoop(portableDance_t* dance, int64_t elapsedUs)
 void portableDanceLoadSetting(portableDance_t* dance)
 {
     int32_t danceIndex = 0;
-    if (!readNvs32(dance->nvsKey, &danceIndex))
+    if (!readNamespaceNvs32(dance->nvsNs, nvsKeyDanceIndex, &danceIndex))
     {
-        writeNvs32(dance->nvsKey, danceIndex);
+        writeNamespaceNvs32(dance->nvsNs, nvsKeyDanceIndex, danceIndex);
     }
 
     if (danceIndex < 0)
@@ -94,6 +102,38 @@ void portableDanceLoadSetting(portableDance_t* dance)
     }
 
     dance->danceIndex = (uint8_t)danceIndex;
+
+    int32_t speed = DANCE_SPEED_MULT;
+    if (!readNamespaceNvs32(dance->nvsNs, nvsKeyDanceSpeed, &speed))
+    {
+        writeNamespaceNvs32(dance->nvsNs, nvsKeyDanceSpeed, speed);
+    }
+    dance->speed = speed;
+}
+
+/**
+ * @brief Sets the current LED dance to the one specified, if within range, and updates the saved index. This works even
+ * if a dance is disabled.
+ *
+ * @param dance The portableDance_t pointer to update
+ * @param danceIndex The index of the dance to select
+ * @return true if the dance was within the array range, false if not
+ */
+bool portableDanceSetByIndex(portableDance_t* dance, uint8_t danceIndex)
+{
+    if (danceIndex >= getNumDances())
+    {
+        return false;
+    }
+
+    dance->danceIndex = danceIndex;
+    dance->resetDance = true;
+
+    if (dance->nvsNs != NULL)
+    {
+        writeNamespaceNvs32(dance->nvsNs, nvsKeyDanceIndex, dance->danceIndex);
+    }
+    return true;
 }
 
 /**
@@ -110,17 +150,25 @@ bool portableDanceSetByName(portableDance_t* dance, const char* danceName)
     {
         if (!strcmp(dance->dances[i].dance->name, danceName))
         {
-            dance->danceIndex = i;
-            dance->resetDance = true;
-
-            if (dance->nvsKey != NULL)
-            {
-                writeNvs32(dance->nvsKey, dance->danceIndex);
-            }
-            return true;
+            return portableDanceSetByIndex(dance, i);
         }
     }
     return false;
+}
+
+/**
+ * @brief Sets the current LED dance speed and persists it to NVS if there is an NVS namespace set.
+ *
+ * @param dance The portableDance_t pointer to update
+ * @param speed The dance speed to set. Dance will run at ::DANCE_SPEED_MULT / speed
+ */
+void portableDanceSetSpeed(portableDance_t* dance, int32_t speed)
+{
+    dance->speed = speed;
+    if (dance->nvsNs != NULL)
+    {
+        writeNamespaceNvs32(dance->nvsNs, nvsKeyDanceSpeed, speed);
+    }
 }
 
 /**
@@ -146,9 +194,9 @@ void portableDanceNext(portableDance_t* dance)
 
     dance->resetDance = true;
 
-    if (dance->nvsKey != NULL)
+    if (dance->nvsNs != NULL)
     {
-        writeNvs32(dance->nvsKey, dance->danceIndex);
+        writeNamespaceNvs32(dance->nvsNs, nvsKeyDanceIndex, dance->danceIndex);
     }
 }
 
@@ -174,9 +222,9 @@ void portableDancePrev(portableDance_t* dance)
 
     dance->resetDance = true;
 
-    if (dance->nvsKey != NULL)
+    if (dance->nvsNs != NULL)
     {
-        writeNvs32(dance->nvsKey, dance->danceIndex);
+        writeNamespaceNvs32(dance->nvsNs, nvsKeyDanceIndex, dance->danceIndex);
     }
 }
 

--- a/main/modes/utilities/dance/portableDance.h
+++ b/main/modes/utilities/dance/portableDance.h
@@ -4,6 +4,9 @@
 #include "swadge2024.h"
 #include "dance.h"
 
+/// Speed scaling factor. Actual speed will be DANCE_SPEED_MULT / speed
+#define DANCE_SPEED_MULT 8
+
 typedef struct
 {
     const ledDance_t* dance;
@@ -19,17 +22,20 @@ typedef struct
     bool resetDance;
 
     uint8_t danceIndex;
+    int32_t speed;
 
-    // If non-NULL, the dance index will be saved/loaded from this nvs key
-    const char* nvsKey;
+    // If non-NULL, the dance index and speed will be saved/loaded from this NVS namespace
+    const char* nvsNs;
 } portableDance_t;
 
-portableDance_t* initPortableDance(const char* nvsKey);
+portableDance_t* initPortableDance(const char* nvsNs);
 void freePortableDance(portableDance_t* dance);
 void portableDanceMainLoop(portableDance_t* dance, int64_t elapsedUs);
+bool portableDanceSetByIndex(portableDance_t* dance, uint8_t danceIndex);
 bool portableDanceSetByName(portableDance_t* dance, const char* danceName);
 void portableDanceNext(portableDance_t* dance);
 void portableDancePrev(portableDance_t* dance);
+void portableDanceSetSpeed(portableDance_t* dance, int32_t speed);
 bool portableDanceDisableDance(portableDance_t* dance, const char* danceName);
 const char* portableDanceGetName(portableDance_t* dance);
 


### PR DESCRIPTION
## Description

The LED dance and speed will now persist to what the user last selected.

## Test Instructions

1. Run the Light Dance mode (or just wait for it to start on its own).
2. Select a dance and a speed.
3. Leave the mode and reenter.
4. Ensure the speed and mode are what you selected before.
5. You didn't forget what you selected before, right?
6. Right?

## Ticket Links

https://github.com/AEFeinstein/Super-2024-Swadge-FW/issues/520

## Readiness Checklist

### Code Quality

- [x] I have run `make format` to format the changes
- [x] I have compiled the firmware and the changes have no warnings
- [x] I have compiled the emulator and the changes have no warnings
- [x] I have run `make cppcheck` and checked that `cppcheck_result.txt` has no warnings for the changes
- [x] I have added doxygen comments to any code used by more than one Swadge mode. This includes `/*! \file` comments with Design Philosophy, Usage, and Example sections for new headers.
- [x] I have run `make docs` and checked that `doxy_warnings.txt` has no warnings for the new code

### Feature Usage

<!--- These aren't mandatory, especially for non-game tickets, but are strongly encouraged -->

- [x] As much hardware input is used as reasonable (buttons, touchpad, IMU, microphone)
- [x] As much hardware output is used as reasonable (screen, LEDs, speaker)
- [ ] [Trophy](https://adam.feinste.in/Super-2024-Swadge-FW/trophy_8h.html) support is integrated
- [ ] [SwadgePass](https://adam.feinste.in/Super-2024-Swadge-FW/swadgePass_8h.html) support is integrated
