### PR TITLE
Always reset midiPlayer_t::songEnding flag

### DIFF
--- a/main/midi/midiPlayer.c
+++ b/main/midi/midiPlayer.c
@@ -1392,6 +1392,7 @@ static void midiSongEnd(midiPlayer_t* player)
     {
         midiAllNotesOff(player, 0);
     }
+    player->songEnding = false;
 
     if (player->loop && player->mode == MIDI_FILE && player->reader.file)
     {
@@ -1399,7 +1400,6 @@ static void midiSongEnd(midiPlayer_t* player)
         player->sampleCount = 0;
         player->tick        = 0;
         player->paused      = false;
-        player->songEnding  = false;
     }
     else
     {
@@ -1457,7 +1457,8 @@ void midiPlayerReset(midiPlayer_t* player)
     player->headroom       = MIDI_DEF_HEADROOM;
 
     deinitMidiParser(&player->reader);
-    player->paused = true;
+    player->paused     = true;
+    player->songEnding = false;
 }
 
 void midiPlayerResetNewSong(midiPlayer_t* player)
@@ -1471,6 +1472,7 @@ void midiPlayerResetNewSong(midiPlayer_t* player)
     player->tick             = 0;
     player->eventAvailable   = false;
     player->forceCheckEvents = true;
+    player->songEnding       = false;
 }
 
 int32_t midiPlayerStep(midiPlayer_t* player)


### PR DESCRIPTION
## Description

Fixes `midiPlayer_t::songEnding` not being reset, preventing any notes from ever playing once the first song has ended.

## Test Instructions

Tested by cherry-picking onto the `swadge-land-mega` branch. The level select screen has sound effects and without the fix, it only plays the very first time and never again.

## Ticket Links

<!--- Link any tickets that are completed in this pull request. -->

## Readiness Checklist

### Code Quality

- [x] I have run `make format` to format the changes
- [x] I have compiled the firmware and the changes have no warnings
- [x] I have compiled the emulator and the changes have no warnings
- [x] I have run `make cppcheck` and checked that `cppcheck_result.txt` has no warnings for the changes
- [ ] I have added doxygen comments to any code used by more than one Swadge mode. This includes `/*! \file` comments with Design Philosophy, Usage, and Example sections for new headers.
- [ ] I have run `make docs` and checked that `doxy_warnings.txt` has no warnings for the new code

### Feature Usage

<!--- These aren't mandatory, especially for non-game tickets, but are strongly encouraged -->

- [ ] As much hardware input is used as reasonable (buttons, touchpad, IMU, microphone)
- [ ] As much hardware output is used as reasonable (screen, LEDs, speaker)
- [ ] [Trophy](https://adam.feinste.in/Super-2024-Swadge-FW/trophy_8h.html) support is integrated
- [ ] [SwadgePass](https://adam.feinste.in/Super-2024-Swadge-FW/swadgePass_8h.html) support is integrated
