### PR TITLE
Gamepad eyes

### DIFF
--- a/main/modes/utilities/gamepad/gamepad.c
+++ b/main/modes/utilities/gamepad/gamepad.c
@@ -797,6 +797,11 @@ void gamepadMainLoop(int64_t elapsedUs __attribute__((unused)))
                 bitmap[5][6]  = (gamepad->gpState.buttons & GAMEPAD_BUTTON_TR2) ? EYE_LED_BRIGHT : 0;
                 bitmap[5][11] = (gamepad->gpState.buttons & GAMEPAD_BUTTON_TR) ? EYE_LED_BRIGHT : 0;
 
+                bitmap[0][0]  = (gamepad->gpState.buttons & GAMEPAD_BUTTON_Z) ? EYE_LED_BRIGHT : 0;
+                bitmap[0][5]  = (gamepad->gpState.buttons & GAMEPAD_BUTTON_SELECT) ? EYE_LED_BRIGHT : 0;
+                bitmap[0][6]  = (gamepad->gpState.buttons & GAMEPAD_BUTTON_START) ? EYE_LED_BRIGHT : 0;
+                bitmap[0][11] = (gamepad->gpState.buttons & GAMEPAD_BUTTON_MODE) ? EYE_LED_BRIGHT : 0;
+
                 btnBrightness = (gamepad->gpState.buttons & GAMEPAD_BUTTON_X) ? EYE_LED_BRIGHT : 0;
                 bitmap[5][8]  = btnBrightness;
                 bitmap[5][9]  = btnBrightness;


### PR DESCRIPTION
## Description

Updated gamepad so that controller state is displayed on the eye LED array as shown below:

<img width="724" height="443" alt="image" src="https://github.com/user-attachments/assets/4a4ce4b3-e069-4332-b74e-93c53618e40e" />


## Test Instructions

On hardware, connected to a Switch
On hardware, connected to PC

## Ticket Links

#519 

## Readiness Checklist

### Code Quality

- [x] I have run `make format` to format the changes