### PR TITLE
Fix orchestra hit program ID

### DIFF
--- a/main/midi/midiData.c
+++ b/main/midi/midiData.c
@@ -769,7 +769,7 @@ const midiTimbre_t* const mmxTimbres[] = {
 };
 
 const uint8_t mmxTimbreMap[] = {
-    11, 17, 24, 29, 30, 36, 38, 48, 50, 62, 80, 81, 82, 83, 119,
+    11, 17, 24, 29, 30, 36, 38, 48, 55, 62, 80, 81, 82, 83, 119,
 };
 
 const size_t mmxTimbreCount = sizeof(mmxTimbres) / sizeof(*mmxTimbres);


### PR DESCRIPTION
## Description

Fixes the ID of the MMX Orchestra Hit instrument

## Test Instructions

Play Maximum Hype (Credits) in the emulator and make sure something gets assigned to 'MMX Orchestra Hit'

## Ticket Links

<!--- Link any tickets that are completed in this pull request. -->

## Readiness Checklist

### Code Quality

- [ ] I have run `make format` to format the changes
- [ ] I have compiled the firmware and the changes have no warnings
- [ ] I have compiled the emulator and the changes have no warnings
- [ ] I have run `make cppcheck` and checked that `cppcheck_result.txt` has no warnings for the changes
- [ ] I have added doxygen comments to any code used by more than one Swadge mode. This includes `/*! \file` comments with Design Philosophy, Usage, and Example sections for new headers.
- [ ] I have run `make docs` and checked that `doxy_warnings.txt` has no warnings for the new code

### Feature Usage

<!--- These aren't mandatory, especially for non-game tickets, but are strongly encouraged -->

- [ ] As much hardware input is used as reasonable (buttons, touchpad, IMU, microphone)
- [ ] As much hardware output is used as reasonable (screen, LEDs, speaker)
- [ ] [Trophy](https://adam.feinste.in/Super-2024-Swadge-FW/trophy_8h.html) support is integrated
- [ ] [SwadgePass](https://adam.feinste.in/Super-2024-Swadge-FW/swadgePass_8h.html) support is integrated
