### PR TITLE
Correct Tunernome tuner LED positions

### DIFF
--- a/main/modes/music/tunernome/tunernome.c
+++ b/main/modes/music/tunernome/tunernome.c
@@ -282,43 +282,56 @@ const uint16_t freqBinIdxsBanjo[] = {
 };
 
 /**
- * Left-to-right on the strings display on-screen, which hardware LED index looks like it phyiscally corresponds to each string?
- * LEDs lit for each string will go through one lookup:
+ * Left-to-right on the strings display on-screen, which hardware LED index looks like it physically corresponds to each
+ * string? LEDs lit for each string will go through one lookup:
  *   - String index is transformed (here in sixNoteStringIdxToLedIdx) to get a physical LED index.
+ *
  * Strings displayed on-screen will go through two lookups:
  *   - First, string index is transformed (here with sixNoteStringIdxToLedIdx) to get a physical LED index.
- *   - Then, that physical LED index is transformed (with ledIdxToPos) to get the "up" vs "down" position of the LED, to draw the note name in the matching location.
- * The best way to make this list is to look at the physical hardware in a sweep left-to-right and write down the LED indices as you hit them.
+ *   - Then, that physical LED index is transformed (with ledIdxToPos) to get the "up" vs "down" position of the LED, to
+ *     draw the note name in the matching location.
+ *
+ * The best way to make this list is to look at the physical hardware in a sweep left-to-right and write down the LED
+ * indices as you hit them.
  */
 const uint16_t sixNoteStringIdxToLedIdx[] = {4, 5, 3, 2, 0, 1};
 
 /**
- * Left-to-right on the strings display on-screen, which hardware LED index looks like it phyiscally corresponds to each string?
- * LEDs lit for each string will go through one lookup:
+ * Left-to-right on the strings display on-screen, which hardware LED index looks like it physically corresponds to each
+ * string? LEDs lit for each string will go through one lookup:
  *   - String index is transformed (here in sixNoteStringIdxToLedIdx) to get a physical LED index.
+ *
  * Strings displayed on-screen will go through two lookups:
  *   - First, string index is transformed (here with sixNoteStringIdxToLedIdx) to get a physical LED index.
- *   - Then, that physical LED index is transformed (with ledIdxToPos) to get the "up" vs "down" position of the LED, to draw the note name in the matching location.
- * The best way to make this list is to follow the instructions for making the six-string list, then cut out the least-symmetrical LED (or the least-noticeable LED to have turned off.)
+ *   - Then, that physical LED index is transformed (with ledIdxToPos) to get the "up" vs "down" position of the LED, to
+ *     draw the note name in the matching location.
+ *
+ * The best way to make this list is to follow the instructions for making the six-string list, then cut out the
+ * least-symmetrical LED (or the least-noticeable LED to have turned off.)
  */
 const uint16_t fiveNoteStringIdxToLedIdx[] = {4, 5, 2, 0, 1};
 
 /**
- * Left-to-right on the strings display on-screen, which hardware LED index looks like it phyiscally corresponds to each string?
- * LEDs lit for each string will go through one lookup:
+ * Left-to-right on the strings display on-screen, which hardware LED index looks like it physically corresponds to each
+ * string? LEDs lit for each string will go through one lookup:
  *   - String index is transformed (here in sixNoteStringIdxToLedIdx) to get a physical LED index.
+ *
  * Strings displayed on-screen will go through two lookups:
  *   - First, string index is transformed (here with sixNoteStringIdxToLedIdx) to get a physical LED index.
- *   - Then, that physical LED index is transformed (with ledIdxToPos) to get the "up" vs "down" position of the LED, to draw the note name in the matching location.
- * The best way to make this list is to follow the instructions for making the six-string list, then cut out the 2 least-symmetrical LEDs (or the 2 least-noticeable LEDs to have turned off.)
+ *   - Then, that physical LED index is transformed (with ledIdxToPos) to get the "up" vs "down" position of the LED, to
+ *     draw the note name in the matching location.
+ *
+ * The best way to make this list is to follow the instructions for making the six-string list, then cut out the 2
+ * least-symmetrical LEDs (or the 2 least-noticeable LEDs to have turned off.)
  */
 const uint16_t fourNoteStringIdxToLedIdx[] = {4, 3, 2, 1};
 
 /**
- * Starting from LED index 0, and going up in index (which could be any direction on physical hardware), does each LED look higher or lower?
- * "LED_POS_UP" and "LED_POS_DOWN" will draw note names above or below the instrument name, respectively.
- * If LEDs are in a line, make them all LED_POS_UP if they're above the screen, or LED_POS_DOWN if they're below the screen.
- * The indices of this array do NOT correspond to left-to-right on the strings display on-screen. That's handled by sixNoteStringIdxToLedIdx, fiveNoteStringIdxToLedIdx, and fourNoteStringIdxToLedIdx.
+ * Starting from LED index 0, and going up in index (which could be any direction on physical hardware), does each LED
+ * look higher or lower? "LED_POS_UP" and "LED_POS_DOWN" will draw note names above or below the instrument name,
+ * respectively. If LEDs are in a line, make them all LED_POS_UP if they're above the screen, or LED_POS_DOWN if they're
+ * below the screen. The indices of this array do NOT correspond to left-to-right on the strings display on-screen.
+ * That's handled by sixNoteStringIdxToLedIdx, fiveNoteStringIdxToLedIdx, and fourNoteStringIdxToLedIdx.
  */
 const led_position_t ledIdxToPos[CONFIG_NUM_LEDS]
     = {LED_POS_UP, LED_POS_DOWN, LED_POS_DOWN, LED_POS_DOWN, LED_POS_DOWN, LED_POS_UP};


### PR DESCRIPTION
## Description

<!--- What was added and/or fixed in this pull request? -->
- Correct Tunernome tuner LED positions
- Add comments and instructions describing how to generate these position arrays
- Reorder these arrays to match instructions

## Test Instructions

<!--- How was this tested? -->

## Ticket Links

<!--- Link any tickets that are completed in this pull request. -->

## Readiness Checklist

### Code Quality

- [ ] I have run `make format` to format the changes
- [ ] I have compiled the firmware and the changes have no warnings
- [ ] I have compiled the emulator and the changes have no warnings
- [ ] I have run `make cppcheck` and checked that `cppcheck_result.txt` has no warnings for the changes
- [ ] I have added doxygen comments to any code used by more than one Swadge mode. This includes `/*! \file` comments with Design Philosophy, Usage, and Example sections for new headers.
- [ ] I have run `make docs` and checked that `doxy_warnings.txt` has no warnings for the new code

### Feature Usage

<!--- These aren't mandatory, especially for non-game tickets, but are strongly encouraged -->

- [ ] As much hardware input is used as reasonable (buttons, touchpad, IMU, microphone)
- [ ] As much hardware output is used as reasonable (screen, LEDs, speaker)
- [ ] [Trophy](https://adam.feinste.in/Super-2024-Swadge-FW/trophy_8h.html) support is integrated
- [ ] [SwadgePass](https://adam.feinste.in/Super-2024-Swadge-FW/swadgePass_8h.html) support is integrated
