### PR TITLE
Fix name picker index offsets

### DIFF
--- a/main/utils/nameList.c
+++ b/main/utils/nameList.c
@@ -162,7 +162,6 @@ void initUsernameSystem()
         // Unpack currently stored data
         setUsernameFrom32(&swadgeUsername, packed);
     }
-    setUsernameFromND(&swadgeUsername);
     // ESP_LOGI("USRN", "Current name code: %d, which is %d, %d, %d, %d", GET_PACKED_USERNAME(swadgeUsername),
     // swadgeUsername.idxs[0], swadgeUsername.idxs[1], swadgeUsername.idxs[2], swadgeUsername.randCode);
 }
@@ -454,12 +453,7 @@ static void _getWordFromList(int listIdx, int idx, char* buffer, int buffLen)
 static uint8_t _checkIfUserIdxInBounds(int8_t idx, uint8_t arrSize, uint8_t seed)
 {
     int range = arrSize >> USER_LIST_SHIFT;
-    while (idx < seed)
-    {
-        idx += range;
-    }
-    idx %= range;
-    return idx;
+    return ((idx - seed + arrSize) % range + seed) % arrSize;
 }
 
 // Drawing functions
@@ -499,7 +493,7 @@ static void _drawFadingWords(nameData_t* nd)
             }
             default:
             {
-                break;
+                continue;
             }
         }
         for (int offset = 1; offset < 4; offset++)


### PR DESCRIPTION
## Description

The name picker was only showing items 0-9 for every user no matter what their MAC address seeds were. This fixes the offsets to prevent us from having 5,000 `sassy-moist-banana`s.

## Test Instructions

1. Edit your SwadgePass sona on more than one swadge/emulator.
2. Ensure that the name picker options are different for each swadge.
3. Ensure that when pressing up/down on the name picker options, the order of the words does not change.
4. Ensure that the selected name persists properly when the swadge is rebooted.
5. Test SwadgePass and ensure that the name appears correctly on the other swadge.

## Ticket Links

https://github.com/AEFeinstein/Super-2024-Swadge-FW/issues/417

## Readiness Checklist

### Code Quality

- [x] I have run `make format` to format the changes
- [x] I have compiled the firmware and the changes have no warnings
- [x] I have compiled the emulator and the changes have no warnings
- [x] I have run `make cppcheck` and checked that `cppcheck_result.txt` has no warnings for the changes
- [x] I have added doxygen comments to any code used by more than one Swadge mode. This includes `/*! \file` comments with Design Philosophy, Usage, and Example sections for new headers.
- [x] I have run `make docs` and checked that `doxy_warnings.txt` has no warnings for the new code

### Feature Usage

<!--- These aren't mandatory, especially for non-game tickets, but are strongly encouraged -->

- [ ] As much hardware input is used as reasonable (buttons, touchpad, IMU, microphone)
- [ ] As much hardware output is used as reasonable (screen, LEDs, speaker)
- [ ] [Trophy](https://adam.feinste.in/Super-2024-Swadge-FW/trophy_8h.html) support is integrated
- [ ] [SwadgePass](https://adam.feinste.in/Super-2024-Swadge-FW/swadgePass_8h.html) support is integrated
