### PR TITLE
More accurately calculate MIDI ticks from sampleCount

### DIFF
--- a/main/midi/midiFileParser.c
+++ b/main/midi/midiFileParser.c
@@ -888,8 +888,14 @@ bool loadMidiFile(cnfsFileIdx_t fIdx, midiFile_t* file, bool spiRam)
 
 void unloadMidiFile(midiFile_t* file)
 {
-    heap_caps_free(file->tracks);
-    heap_caps_free(file->data);
+    if (file->tracks)
+    {
+        heap_caps_free(file->tracks);
+    }
+    if (file->data)
+    {
+        heap_caps_free(file->data);
+    }
     memset(file, 0, sizeof(midiFile_t));
 }
 

--- a/main/midi/midiPlayer.h
+++ b/main/midi/midiPlayer.h
@@ -785,9 +785,6 @@ typedef struct
     /// @brief The number of microseconds per quarter note
     uint32_t tempo;
 
-    /// @brief The number of audio samples per MIDI tick
-    uint32_t samplesPerTick;
-
     /// @brief True when playback of the current file is paused
     bool paused;
 


### PR DESCRIPTION
Get rid of samplesPerTick

## Description

Fix an integer rounding issue which causes MIDIs to play slightly faster than they should

## Test Instructions

Play Swadge Hero in the `mpex-hero` branch and validate that note tracks and song sync up

## Ticket Links

n/a

## Readiness Checklist

### Code Quality

- [x] I have run `make format` to format the changes
- [x] I have compiled the firmware and the changes have no warnings
- [x] I have compiled the emulator and the changes have no warnings
- [ ] I have run `make cppcheck` and checked that `cppcheck_result.txt` has no warnings for the changes
- [ ] I have added doxygen comments to any code used by more than one Swadge mode. This includes `/*! \file` comments with Design Philosophy, Usage, and Example sections for new headers.
- [x] I have run `make docs` and checked that `doxy_warnings.txt` has no warnings for the new code

### Feature Usage

<!--- These aren't mandatory, especially for non-game tickets, but are strongly encouraged -->

- [ ] As much hardware input is used as reasonable (buttons, touchpad, IMU, microphone)
- [ ] As much hardware output is used as reasonable (screen, LEDs, speaker)
- [ ] [Trophy](https://adam.feinste.in/Super-2024-Swadge-FW/trophy_8h.html) support is integrated
- [ ] [SwadgePass](https://adam.feinste.in/Super-2024-Swadge-FW/swadgePass_8h.html) support is integrated