### PR TITLE
Mpex james2

### DIFF
--- a/main/modes/games/platformer/megaPulseEx.c
+++ b/main/modes/games/platformer/megaPulseEx.c
@@ -2257,6 +2257,11 @@ void stopMusic(void)
     globalMidiPlayerGet(MIDI_BGM)->paused = true;
 }
 
+void loseCanOfSalsa(void)
+{
+    platformer->gameData.abilities &= ~(1U << MG_CAN_OF_SALSA_ABILITY);
+}
+
 // forward declared in mega_pulse_ex_typedef.h
 void initBossFight(void)
 {

--- a/main/modes/games/platformer/mega_pulse_ex_typedef.h
+++ b/main/modes/games/platformer/mega_pulse_ex_typedef.h
@@ -1170,5 +1170,6 @@ extern void startTrashManMusic(void);
 extern void initBossFight(void);
 extern void startMegajamMusic(void);
 extern void stopMusic(void);
+extern void loseCanOfSalsa(void);
 
 #endif

--- a/main/modes/games/platformer/mgCutscenes.c
+++ b/main/modes/games/platformer/mgCutscenes.c
@@ -525,7 +525,7 @@ void bossIntroCutscene(mgGameData_t* gameData)
                 addCutsceneLine(gameData->cutscene, Pulse, "Uh, yeah?", false, 0, NULL);
                 addCutsceneLine(gameData->cutscene, KineticDonutUncorrupted, "GIMMIE.", false, -1, NULL);
                 addCutsceneLine(gameData->cutscene, Pulse, "Umm... sure?", false, 0, NULL);
-                addCutsceneLine(gameData->cutscene, SystemText, "PULSE tosses KINETIC DONUT the can. He rips it open and drinks it like a sports drink.", false, 0, NULL);
+                addCutsceneLine(gameData->cutscene, SystemText, "PULSE tosses KINETIC DONUT the can. He rips it open and drinks it like a sports drink.", false, 0, loseCanOfSalsa);
                 addCutsceneLine(gameData->cutscene, KineticDonutUncorrupted, "OHHH you're a LIFESAVER! I think I was just hangry. My brain was stuck in \"party mode.\"", false, -1, NULL);
                 addCutsceneLine(gameData->cutscene, Pulse, "So... we're good?", false, 2, NULL);
                 addCutsceneLine(gameData->cutscene, KineticDonutUncorrupted, "More than good. You fixed my vibe... Here - take this. Now go stick it to whoever cancelled lunch!", false, -1, startPostFightMusic);


### PR DESCRIPTION
## Description

Hooray, the wplace coordinates were wrong. Needs a minus sign.

## Test Instructions


## Ticket Links

https://github.com/AEFeinstein/Super-2024-Swadge-FW/issues/514

## Readiness Checklist

### Code Quality

- [ ] I have run `make format` to format the changes
- [ ] I have compiled the firmware and the changes have no warnings
- [ ] I have compiled the emulator and the changes have no warnings
- [ ] I have run `make cppcheck` and checked that `cppcheck_result.txt` has no warnings for the changes
- [ ] I have added doxygen comments to any code used by more than one Swadge mode. This includes `/*! \file` comments with Design Philosophy, Usage, and Example sections for new headers.
- [ ] I have run `make docs` and checked that `doxy_warnings.txt` has no warnings for the new code

### Feature Usage

<!--- These aren't mandatory, especially for non-game tickets, but are strongly encouraged -->

- [ ] As much hardware input is used as reasonable (buttons, touchpad, IMU, microphone)
- [ ] As much hardware output is used as reasonable (screen, LEDs, speaker)
- [ ] [Trophy](https://adam.feinste.in/Super-2024-Swadge-FW/trophy_8h.html) support is integrated
- [ ] [SwadgePass](https://adam.feinste.in/Super-2024-Swadge-FW/swadgePass_8h.html) support is integrated
