### PR TITLE
Fix Kinetic Donut softlock

### DIFF
--- a/main/modes/games/platformer/mgEntity.c
+++ b/main/modes/games/platformer/mgEntity.c
@@ -114,7 +114,8 @@ void mg_initializeEntity(mgEntity_t* self, mgEntityManager_t* entityManager, mgT
 
 void mg_updatePlayer(mgEntity_t* self)
 {
-    if (self->gameData->level == 1 && !self->gameData->kineticSkipped && self->x > 59770 && self->y < 15400)
+    if (self->gameData->level == 1 && !self->gameData->kineticSkipped && self->x > 59770 && self->y < 15400
+        && self->gameData->abilities & (1U << MG_CAN_OF_SALSA_ABILITY))
     {
         self->gameData->kineticSkipped = true;
         bossIntroCutscene(self->gameData);

--- a/main/modes/games/platformer/mgEntityManager.c
+++ b/main/modes/games/platformer/mgEntityManager.c
@@ -2296,7 +2296,7 @@ mgEntity_t* createBossKineticDonut(mgEntityManager_t* entityManager, uint16_t x,
 {
     // Boss skip if you have can of salsa in level 1.
     if (entityManager->playerEntity != NULL && entityManager->playerEntity->gameData->level == 1
-        && entityManager->playerEntity->gameData->abilities & (1U << MG_CAN_OF_SALSA_ABILITY))
+        && entityManager->playerEntity->gameData->kineticSkipped)
     {
         return createMixtape(entityManager, x, y);
     }


### PR DESCRIPTION
## Description

Fix kinetic donut softlock

## Test Instructions

## Ticket Links

https://github.com/AEFeinstein/Super-2024-Swadge-FW/issues/514

## Readiness Checklist

### Code Quality

- [x] I have run `make format` to format the changes
- [x] I have compiled the firmware and the changes have no warnings
- [x] I have compiled the emulator and the changes have no warnings
- [ ] I have run `make cppcheck` and checked that `cppcheck_result.txt` has no warnings for the changes
- [ ] I have added doxygen comments to any code used by more than one Swadge mode. This includes `/*! \file` comments with Design Philosophy, Usage, and Example sections for new headers.
- [ ] I have run `make docs` and checked that `doxy_warnings.txt` has no warnings for the new code

### Feature Usage

<!--- These aren't mandatory, especially for non-game tickets, but are strongly encouraged -->

- [ ] As much hardware input is used as reasonable (buttons, touchpad, IMU, microphone)
- [ ] As much hardware output is used as reasonable (screen, LEDs, speaker)
- [ ] [Trophy](https://adam.feinste.in/Super-2024-Swadge-FW/trophy_8h.html) support is integrated
- [ ] [SwadgePass](https://adam.feinste.in/Super-2024-Swadge-FW/swadgePass_8h.html) support is integrated
