### PR TITLE
Fix atrium

### DIFF
--- a/main/modes/games/cosCrunch/cosCrunch.c
+++ b/main/modes/games/cosCrunch/cosCrunch.c
@@ -339,7 +339,8 @@ static void cosCrunchEnterMode(void)
 
     list_t swadgePasses = {0};
     getSwadgePasses(&swadgePasses, &cosCrunchMode, false);
-    saveHighScoresFromSwadgePass(&cc->highScores, CC_NVS_NAMESPACE, swadgePasses, &cosCrunchMode, cosCrunchGetSwadgePassHighScore);
+    saveHighScoresFromSwadgePass(&cc->highScores, CC_NVS_NAMESPACE, swadgePasses, &cosCrunchMode,
+                                 cosCrunchGetSwadgePassHighScore);
     freeSwadgePasses(&swadgePasses);
 
     int32_t tutorialSeen;


### PR DESCRIPTION
## Description

* Draw bodies in SwadgePass cards
* Refactor Atrium bodies to be shown and not change when changing pages L/R
* Draw bassist body by default, just in case
* Fix out-of-bounds crash when scrolling to the last Atrium page
* Sanitize received Atrium profile data
* Remove redundant TFT defines
* Use const arrays where possible

## Test Instructions

* Enter Atrium with max SwadgePasses
* Scroll all the way to the right of the viewer
* Repeatedly scroll through the mainstage lobby and ensure all bodies are present
* View profile cards in Atrium and ensure bodies are present

## Ticket Links

#616 

## Readiness Checklist

### Code Quality

- [x] I have run `make format` to format the changes
- [x] I have compiled the firmware and the changes have no warnings
- [x] I have compiled the emulator and the changes have no warnings
- [ ] I have run `make cppcheck` and checked that `cppcheck_result.txt` has no warnings for the changes
- [ ] I have added doxygen comments to any code used by more than one Swadge mode. This includes `/*! \file` comments with Design Philosophy, Usage, and Example sections for new headers.
- [ ] I have run `make docs` and checked that `doxy_warnings.txt` has no warnings for the new code

### Feature Usage

- [ ] As much hardware input is used as reasonable (buttons, touchpad, IMU, microphone)
- [ ] As much hardware output is used as reasonable (screen, LEDs, speaker)
- [ ] [Trophy](https://adam.feinste.in/Super-2024-Swadge-FW/trophy_8h.html) support is integrated
- [x] [SwadgePass](https://adam.feinste.in/Super-2024-Swadge-FW/swadgePass_8h.html) support is integrated