### PR TITLE
#615 Fix tanks W/L string assignment

### DIFF
--- a/main/modes/games/artillery/artillery_game.c
+++ b/main/modes/games/artillery/artillery_game.c
@@ -917,7 +917,7 @@ void artilleryPassTurn(artilleryData_t* ad)
                 }
                 case AG_WIRELESS:
                 {
-                    isP1 = (GOING_FIRST == p2pGetPlayOrder(&ad->p2p));
+                    isP1 = (GOING_SECOND == p2pGetPlayOrder(&ad->p2p));
                     trophyUpdate(&artilleryTrophies[AT_P2P], trophyGetSavedValue(&artilleryTrophies[AT_P2P]) + 1, true);
                     break;
                 }

--- a/main/modes/games/artillery/artillery_game_over.c
+++ b/main/modes/games/artillery/artillery_game_over.c
@@ -83,11 +83,11 @@ void artilleryGameOverLoop(artilleryData_t* ad, uint32_t elapsedUs)
 
             if (thisScore > otherScore)
             {
-                title = str_lose;
+                title = str_win;
             }
             else if (thisScore < otherScore)
             {
-                title = str_win;
+                title = str_lose;
             }
             else
             {

--- a/main/modes/games/platformer/mgEntity.c
+++ b/main/modes/games/platformer/mgEntity.c
@@ -3293,7 +3293,8 @@ void killEnemy(mgEntity_t* target)
         target->updateFunction(target);
     }
 
-    target->visible        = true; //Force ENTITY_DEAD to be visible because updateFunction may flip it to invisible due to invincibilityFrames
+    target->visible = true; // Force ENTITY_DEAD to be visible because updateFunction may flip it to invisible due to
+                            // invincibilityFrames
     target->updateFunction = (isABoss) ? &updateBossDead : &updateEntityDead;
 }
 


### PR DESCRIPTION
## Description

Fixed win/loss string assignment in Vector Tanks

## Test Instructions

1. Play a CPU game, validate that win/loss text is accurate
2. Play a p2p game, validate that win/loss text is accurate
3. Pass and play doesn't matter

## Ticket Links

#615 

## Readiness Checklist

### Code Quality

- [x] I have run `make format` to format the changes
- [x] I have compiled the firmware and the changes have no warnings
- [x] I have compiled the emulator and the changes have no warnings
- [ ] I have run `make cppcheck` and checked that `cppcheck_result.txt` has no warnings for the changes
- [ ] I have added doxygen comments to any code used by more than one Swadge mode. This includes `/*! \file` comments with Design Philosophy, Usage, and Example sections for new headers.
- [ ] I have run `make docs` and checked that `doxy_warnings.txt` has no warnings for the new code

### Feature Usage

<!--- These aren't mandatory, especially for non-game tickets, but are strongly encouraged -->

- [ ] As much hardware input is used as reasonable (buttons, touchpad, IMU, microphone)
- [ ] As much hardware output is used as reasonable (screen, LEDs, speaker)
- [ ] [Trophy](https://adam.feinste.in/Super-2024-Swadge-FW/trophy_8h.html) support is integrated
- [ ] [SwadgePass](https://adam.feinste.in/Super-2024-Swadge-FW/swadgePass_8h.html) support is integrated