### PR TITLE
Fix eye noise in Cosplay Crunch multiplayer

### DIFF
--- a/main/modes/games/cosCrunch/cosCrunch.c
+++ b/main/modes/games/cosCrunch/cosCrunch.c
@@ -550,6 +550,7 @@ static void cosCrunchMainLoop(int64_t elapsedUs)
         cc->interlude.timeUs     = PLAYER_INTERLUDE_TIME_US;
         cc->interlude.elapsedUs  = 0;
         cc->interlude.swirlyEyes = false;
+        ch32v003SelectBitmap(EYES_SLOT_DEFAULT);
     }
 
     switch (cc->state)
@@ -581,10 +582,6 @@ static void cosCrunchMainLoop(int64_t elapsedUs)
                     ch32v003SelectBitmap(EYES_SLOT_SWIRL + frame);
                     cc->interlude.swirlFrame = frame;
                 }
-            }
-            else
-            {
-                ch32v003SelectBitmap(EYES_SLOT_DEFAULT);
             }
 
             cosCrunchClearLeds();


### PR DESCRIPTION
## Description

Setting the same eye image every frame was causing noise. Do it once instead.

## Test Instructions

1. Play multiplayer Cosplay Crunch on real hardware
2. Ensure the eyes don't sparkle when the "Player X get ready!" and "Speed up!" messages appear

## Ticket Links

Fixes #617 

## Readiness Checklist

### Code Quality

- [x] I have run `make format` to format the changes
- [x] I have compiled the firmware and the changes have no warnings
- [x] I have compiled the emulator and the changes have no warnings
- [ ] I have run `make cppcheck` and checked that `cppcheck_result.txt` has no warnings for the changes
- [ ] I have added doxygen comments to any code used by more than one Swadge mode. This includes `/*! \file` comments with Design Philosophy, Usage, and Example sections for new headers.
- [ ] I have run `make docs` and checked that `doxy_warnings.txt` has no warnings for the new code

### Feature Usage

<!--- These aren't mandatory, especially for non-game tickets, but are strongly encouraged -->

- [ ] As much hardware input is used as reasonable (buttons, touchpad, IMU, microphone)
- [ ] As much hardware output is used as reasonable (screen, LEDs, speaker)
- [ ] [Trophy](https://adam.feinste.in/Super-2024-Swadge-FW/trophy_8h.html) support is integrated
- [ ] [SwadgePass](https://adam.feinste.in/Super-2024-Swadge-FW/swadgePass_8h.html) support is integrated
