### PR TITLE
Fix high score util storing unnecessary bytes

### DIFF
--- a/main/utils/highScores.c
+++ b/main/utils/highScores.c
@@ -93,7 +93,7 @@ bool updateHighScores(highScores_t* hs, const char* nvsNamespace, score_t newSco
 
     if (changed)
     {
-        writeNamespaceNvsBlob(nvsNamespace, NVS_KEY_HIGH_SCORES, hs->highScores, sizeof(hs->highScores));
+        writeNamespaceNvsBlob(nvsNamespace, NVS_KEY_HIGH_SCORES, hs->highScores, hs->highScoreCount * sizeof(score_t));
     }
 
     return changed;
@@ -127,7 +127,7 @@ void saveHighScoresFromSwadgePass(highScores_t* hs, const char* nvsNamespace, li
         node = swadgePasses.first;
         while (node)
         {
-            setPacketUsedByMode((swadgePassData_t*)node->val, mode, true);
+            setPacketUsedByMode(node->val, mode, true);
             node = node->next;
         }
 


### PR DESCRIPTION
## Description
When saving high scores, the [high score util](https://github.com/AEFeinstein/Super-2024-Swadge-FW/blob/main/main/utils/highScores.c) was saving the maximum number of possible values (20). Since the number of high scores a mode has is configurable by the mode, it should only be saving the number configured.

## Test Instructions

1. Check the length of the `high_scores` entry for Cosplay Crunch or MPEX in nvs.json. It should be 720 bytes (1440 hex digits).
2. Play a game of either until you get a high score saved.
3. The length of that game's `high_scores` entry in nvs.json should now be 252 bytes (7 entries * 36 bytes) for Cosplay Crunch or 180 bytes (5 entries * 36 bytes) for MPEX.

## Ticket Links

#635 

## Readiness Checklist

### Code Quality

- [x] I have run `make format` to format the changes
- [x] I have compiled the firmware and the changes have no warnings
- [x] I have compiled the emulator and the changes have no warnings
- [ ] I have run `make cppcheck` and checked that `cppcheck_result.txt` has no warnings for the changes
- [ ] I have added doxygen comments to any code used by more than one Swadge mode. This includes `/*! \file` comments with Design Philosophy, Usage, and Example sections for new headers.
- [ ] I have run `make docs` and checked that `doxy_warnings.txt` has no warnings for the new code

### Feature Usage

<!--- These aren't mandatory, especially for non-game tickets, but are strongly encouraged -->

- [ ] As much hardware input is used as reasonable (buttons, touchpad, IMU, microphone)
- [ ] As much hardware output is used as reasonable (screen, LEDs, speaker)
- [ ] [Trophy](https://adam.feinste.in/Super-2024-Swadge-FW/trophy_8h.html) support is integrated
- [ ] [SwadgePass](https://adam.feinste.in/Super-2024-Swadge-FW/swadgePass_8h.html) support is integrated
