### PR TITLE
Added a way to grab individual sprites from a sona

### DIFF
--- a/main/modes/test/sonaTest/sonaTest.c
+++ b/main/modes/test/sonaTest/sonaTest.c
@@ -28,6 +28,8 @@ typedef struct
     int list[OPTION_COUNT];
     bool menu;
     int16_t menuSlot;
+    wsg_t test;
+    int idx;
 } stData_t;
 
 swadgeMode_t sonaTestMode = {
@@ -47,6 +49,7 @@ static void stEnterMode(void)
 
 static void stExitMode(void)
 {
+    freeWsg(&st->test);
     heap_caps_free(st);
 }
 
@@ -174,6 +177,14 @@ static void stMainLoop(int64_t elapsedUs)
     snprintf(buffer, sizeof(buffer) - 1, "Index: %" PRId16, st->list[st->selection]);
     drawText(getSysFont(), c555, buffer, 32, TFT_HEIGHT - 16);
     drawText(getSysFont(), c550, st->swsn.name.nameBuffer, 16, 16);
+
+    // Test pulling individual sprites out
+    /* drawRectFilled(0, 0, TFT_WIDTH, 64, c555);
+    for (int i = 0; i < SWSN_OPTIONS; i++)
+    {
+        getFeatureWSG(&st->swsn, i, &st->test);
+        drawWsgSimple(&st->test, i * 32, 0);
+    } */
 }
 
 static void stCopyListToSona(swadgesona_t* swsn, int* list)

--- a/main/utils/swadgesona.c
+++ b/main/utils/swadgesona.c
@@ -492,10 +492,156 @@ void loadSPSona(swadgesonaCore_t* sw)
     }
 }
 
-// Get indexes
-cnfsFileIdx_t getHairWSG(swadgesona_t* sw)
+// Get images separate from the sona
+bool getFeatureWSG(swadgesona_t* sw, features_t feature, wsg_t* dest)
 {
-    return hairWsgs[sw->core.hairStyle];
+    // Canvas
+    freeWsg(dest);
+    canvasBlankInit(dest, 64, 64, cTransparent, true);
+
+    bool found = false;
+
+    switch (feature)
+    {
+        case SWSN_BODY:
+        {
+            wsgPaletteReset(&sw->pal);
+            _getPaletteFromIdx(&sw->pal, COLOR_SKIN, sw->core.skin);
+            canvasDrawSimplePal(dest, SWSN_HEAD_WSG, 0, 0, &sw->pal);
+            found = true;
+            break;
+        }
+        case SWSN_BODY_MARKS:
+        {
+            if (sw->core.bodyMarks != BME_NONE)
+            {
+                canvasDrawSimplePal(dest, bodymarksWsgs[sw->core.bodyMarks - 1], 0, 0, &sw->pal);
+                found = true;
+            }
+            break;
+        }
+        case SWSN_EARS:
+        {
+            if (sw->core.earShape != EAE_HUMAN)
+            {
+                wsgPaletteReset(&sw->pal);
+                _getPaletteFromIdx(&sw->pal, COLOR_SKIN, sw->core.skin);
+                canvasDrawSimplePal(dest, earWsgs[sw->core.earShape - 1], 0, 0, &sw->pal);
+                found = true;
+            }
+            break;
+        }
+        case SWSN_EYE:
+        {
+            wsgPaletteReset(&sw->pal);
+            _getPaletteFromIdx(&sw->pal, COLOR_EYES, sw->core.eyeColor);
+            canvasDrawSimplePal(dest, eyeWsgs[sw->core.eyeShape], 0, 0, &sw->pal);
+            found = true;
+            break;
+        }
+        case SWSN_EYEBROW:
+        {
+            wsgPaletteReset(&sw->pal);
+            _getPaletteFromIdx(&sw->pal, COLOR_HAIR, sw->core.hairColor);
+            canvasDrawSimplePal(dest, eyebrowsWsgs[sw->core.eyebrows], 0, 0, &sw->pal);
+            found = true;
+            break;
+        }
+        case SWSN_HAIR:
+        {
+            if (sw->core.hairStyle != HE_NONE)
+            {
+                wsgPaletteReset(&sw->pal);
+                _getPaletteFromIdx(&sw->pal, COLOR_HAIR, sw->core.hairColor);
+                canvasDrawSimplePal(dest, hairWsgs[sw->core.hairStyle - 1], 0, 0, &sw->pal);
+                found = true;
+            }
+            break;
+        }
+        case SWSN_HAT:
+        {
+            if (sw->core.hat != HAE_NONE)
+            {
+                wsgPaletteReset(&sw->pal);
+                if (sw->core.hat == HAE_PULSE) // If pulse use special color code
+                {
+                    switch (sw->core.hatColor)
+                    {
+                        case HA_BLUE:
+                        case HA_DARK_BLUE:
+                        {
+                            sw->pal.newColors[c033] = c005;
+                            sw->pal.newColors[c055] = c035;
+                            break;
+                        }
+                        case HA_DARK_GREEN:
+                        case HA_GREEN:
+                        {
+                            sw->pal.newColors[c033] = c142;
+                            sw->pal.newColors[c055] = c252;
+                            break;
+                        }
+                        case HA_HOT_PINK:
+                        case HA_PINK:
+                        case HA_PURPLE:
+                        {
+                            sw->pal.newColors[c033] = c504;
+                            sw->pal.newColors[c055] = c515;
+                            break;
+                        }
+                        case HA_ORANGE: // Red
+                        {
+                            sw->pal.newColors[c033] = c500;
+                            sw->pal.newColors[c055] = c532;
+                            break;
+                        }
+                        case HA_YELLOW:
+                        {
+                            sw->pal.newColors[c033] = c541;
+                            sw->pal.newColors[c055] = c552;
+                            break;
+                        }
+                        default:
+                        {
+                            sw->pal.newColors[c033] = c033;
+                            sw->pal.newColors[c055] = c055;
+                            break;
+                        }
+                    }
+                }
+                else if (sw->core.hat != HAE_BIGMA && sw->core.hat != HAE_BATTRICE && sw->core.hat != HAE_MET_HELMET
+                         && sw->core.hat != HAE_SAWTOOTH)
+                {
+                    _getPaletteFromIdx(&sw->pal, COLOR_HAT, sw->core.hatColor);
+                }
+                // Draw hat
+                found = true;
+                canvasDrawSimplePal(dest, hatWsgs[sw->core.hat - 1], 0, 0, &sw->pal);
+            }
+            break;
+        }
+        case SWSN_MOUTH:
+        {
+            canvasDrawSimple(dest, mouthWsgs[sw->core.mouthShape], 0, 0);
+            found = true;
+            break;
+        }
+        case SWSN_GLASSES:
+        {
+            if (sw->core.glasses != G_NONE)
+            {
+                wsgPaletteReset(&sw->pal);
+                _getPaletteFromIdx(&sw->pal, COLOR_GLASSES, sw->core.glassesColor);
+                canvasDrawSimplePal(dest, glassesWsgs[sw->core.glasses - 1], 0, 0, &sw->pal);
+                found = true;
+            }
+            break;
+        }
+        default:
+        {
+            break;
+        }
+    }
 }
 
 //==============================================================================

--- a/main/utils/swadgesona.c
+++ b/main/utils/swadgesona.c
@@ -642,6 +642,7 @@ bool getFeatureWSG(swadgesona_t* sw, features_t feature, wsg_t* dest)
             break;
         }
     }
+    return found;
 }
 
 //==============================================================================

--- a/main/utils/swadgesona.c
+++ b/main/utils/swadgesona.c
@@ -239,6 +239,14 @@ typedef enum
  */
 static void _getPaletteFromIdx(wsgPalette_t* palette, paletteSwap_t ps, int idx);
 
+/**
+ * @brief Added the hat currently selected in the swadgesona and saves it to the indicated wsg_t.
+ * 
+ * @param sw The swadgesona to pull data from
+ * @param dest The image to write to. Set to the image on the swadgesona if required.
+ */
+static void _splatHat(swadgesona_t* sw, wsg_t* dest);
+
 //==============================================================================
 // Functions
 //==============================================================================
@@ -424,63 +432,7 @@ void generateSwadgesonaImage(swadgesona_t* sw, bool drawBody)
     }
 
     // Hats
-    if (sw->core.hat != HAE_NONE)
-    {
-        wsgPaletteReset(&sw->pal);
-        if (sw->core.hat == HAE_PULSE) // If pulse use special color code
-        {
-            switch (sw->core.hatColor)
-            {
-                case HA_BLUE:
-                case HA_DARK_BLUE:
-                {
-                    sw->pal.newColors[c033] = c005;
-                    sw->pal.newColors[c055] = c035;
-                    break;
-                }
-                case HA_DARK_GREEN:
-                case HA_GREEN:
-                {
-                    sw->pal.newColors[c033] = c142;
-                    sw->pal.newColors[c055] = c252;
-                    break;
-                }
-                case HA_HOT_PINK:
-                case HA_PINK:
-                case HA_PURPLE:
-                {
-                    sw->pal.newColors[c033] = c504;
-                    sw->pal.newColors[c055] = c515;
-                    break;
-                }
-                case HA_ORANGE: // Red
-                {
-                    sw->pal.newColors[c033] = c500;
-                    sw->pal.newColors[c055] = c532;
-                    break;
-                }
-                case HA_YELLOW:
-                {
-                    sw->pal.newColors[c033] = c541;
-                    sw->pal.newColors[c055] = c552;
-                    break;
-                }
-                default:
-                {
-                    sw->pal.newColors[c033] = c033;
-                    sw->pal.newColors[c055] = c055;
-                    break;
-                }
-            }
-        }
-        else if (sw->core.hat != HAE_BIGMA && sw->core.hat != HAE_BATTRICE && sw->core.hat != HAE_MET_HELMET
-                 && sw->core.hat != HAE_SAWTOOTH)
-        {
-            _getPaletteFromIdx(&sw->pal, COLOR_HAT, sw->core.hatColor);
-        }
-        // Draw hat
-        canvasDrawSimplePal(&sw->image, hatWsgs[sw->core.hat - 1], 0, 0, &sw->pal);
-    }
+    _splatHat(sw, &sw->image);
 }
 
 void loadSPSona(swadgesonaCore_t* sw)
@@ -560,63 +512,10 @@ bool getFeatureWSG(swadgesona_t* sw, features_t feature, wsg_t* dest)
         }
         case SWSN_HAT:
         {
+            _splatHat(sw, dest);
             if (sw->core.hat != HAE_NONE)
             {
-                wsgPaletteReset(&sw->pal);
-                if (sw->core.hat == HAE_PULSE) // If pulse use special color code
-                {
-                    switch (sw->core.hatColor)
-                    {
-                        case HA_BLUE:
-                        case HA_DARK_BLUE:
-                        {
-                            sw->pal.newColors[c033] = c005;
-                            sw->pal.newColors[c055] = c035;
-                            break;
-                        }
-                        case HA_DARK_GREEN:
-                        case HA_GREEN:
-                        {
-                            sw->pal.newColors[c033] = c142;
-                            sw->pal.newColors[c055] = c252;
-                            break;
-                        }
-                        case HA_HOT_PINK:
-                        case HA_PINK:
-                        case HA_PURPLE:
-                        {
-                            sw->pal.newColors[c033] = c504;
-                            sw->pal.newColors[c055] = c515;
-                            break;
-                        }
-                        case HA_ORANGE: // Red
-                        {
-                            sw->pal.newColors[c033] = c500;
-                            sw->pal.newColors[c055] = c532;
-                            break;
-                        }
-                        case HA_YELLOW:
-                        {
-                            sw->pal.newColors[c033] = c541;
-                            sw->pal.newColors[c055] = c552;
-                            break;
-                        }
-                        default:
-                        {
-                            sw->pal.newColors[c033] = c033;
-                            sw->pal.newColors[c055] = c055;
-                            break;
-                        }
-                    }
-                }
-                else if (sw->core.hat != HAE_BIGMA && sw->core.hat != HAE_BATTRICE && sw->core.hat != HAE_MET_HELMET
-                         && sw->core.hat != HAE_SAWTOOTH)
-                {
-                    _getPaletteFromIdx(&sw->pal, COLOR_HAT, sw->core.hatColor);
-                }
-                // Draw hat
                 found = true;
-                canvasDrawSimplePal(dest, hatWsgs[sw->core.hat - 1], 0, 0, &sw->pal);
             }
             break;
         }
@@ -1228,5 +1127,66 @@ static void _getPaletteFromIdx(wsgPalette_t* palette, paletteSwap_t ps, int idx)
             }
             break;
         }
+    }
+}
+
+static void _splatHat(swadgesona_t* sw, wsg_t* dest)
+{
+    if (sw->core.hat != HAE_NONE)
+    {
+        wsgPaletteReset(&sw->pal);
+        if (sw->core.hat == HAE_PULSE) // If pulse use special color code
+        {
+            switch (sw->core.hatColor)
+            {
+                case HA_BLUE:
+                case HA_DARK_BLUE:
+                {
+                    sw->pal.newColors[c033] = c005;
+                    sw->pal.newColors[c055] = c035;
+                    break;
+                }
+                case HA_DARK_GREEN:
+                case HA_GREEN:
+                {
+                    sw->pal.newColors[c033] = c142;
+                    sw->pal.newColors[c055] = c252;
+                    break;
+                }
+                case HA_HOT_PINK:
+                case HA_PINK:
+                case HA_PURPLE:
+                {
+                    sw->pal.newColors[c033] = c504;
+                    sw->pal.newColors[c055] = c515;
+                    break;
+                }
+                case HA_ORANGE: // Red
+                {
+                    sw->pal.newColors[c033] = c500;
+                    sw->pal.newColors[c055] = c532;
+                    break;
+                }
+                case HA_YELLOW:
+                {
+                    sw->pal.newColors[c033] = c541;
+                    sw->pal.newColors[c055] = c552;
+                    break;
+                }
+                default:
+                {
+                    sw->pal.newColors[c033] = c033;
+                    sw->pal.newColors[c055] = c055;
+                    break;
+                }
+            }
+        }
+        else if (sw->core.hat != HAE_BIGMA && sw->core.hat != HAE_BATTRICE && sw->core.hat != HAE_MET_HELMET
+                 && sw->core.hat != HAE_SAWTOOTH)
+        {
+            _getPaletteFromIdx(&sw->pal, COLOR_HAT, sw->core.hatColor);
+        }
+        // Draw hat
+        canvasDrawSimplePal(dest, hatWsgs[sw->core.hat - 1], 0, 0, &sw->pal);
     }
 }

--- a/main/utils/swadgesona.h
+++ b/main/utils/swadgesona.h
@@ -500,6 +500,20 @@ typedef enum
     G_COUNT
 } glasses_t;
 
+typedef enum
+{
+    SWSN_BODY,
+    SWSN_BODY_MARKS,
+    SWSN_EARS,
+    SWSN_EYEBROW,
+    SWSN_EYE,
+    SWSN_HAIR,
+    SWSN_HAT,
+    SWSN_MOUTH,
+    SWSN_GLASSES,
+    SWSN_OPTIONS
+} features_t;
+
 //==============================================================================
 // Structs
 //==============================================================================
@@ -603,9 +617,15 @@ void loadSPSona(swadgesonaCore_t* sw);
 
 // Get indexes
 /**
- * @brief Get the hair CNFS index from the swadgesona for drawing behind custom bodies
+ * @brief Copy the sprite and color at an index to a wsg_t. Please erase after use.
+ * 
+ * @note Please note that there are probably some issues with this:
+ * - Human ears are default, and will provide a "false" signal
+ * - There are some special cases I have not handled, including vitiligo, Hair that has to go front and back, etc.
  *
  * @param sw Swadgesona to extract wsg from
- * @return cnfsFileIdx_t index into the CNFS system where the hairstyle is at.
+ * @param feature The feature to load 
+ * @param dest The place to save the file into
+ * @return bool True if it found a sprite, false otherwise
  */
-cnfsFileIdx_t getHairWSG(swadgesona_t* sw);
+bool getFeatureWSG(swadgesona_t* sw, features_t feature, wsg_t* dest);

--- a/main/utils/swadgesona.h
+++ b/main/utils/swadgesona.h
@@ -618,13 +618,13 @@ void loadSPSona(swadgesonaCore_t* sw);
 // Get indexes
 /**
  * @brief Copy the sprite and color at an index to a wsg_t. Please erase after use.
- * 
+ *
  * @note Please note that there are probably some issues with this:
  * - Human ears are default, and will provide a "false" signal
  * - There are some special cases I have not handled, including vitiligo, Hair that has to go front and back, etc.
  *
  * @param sw Swadgesona to extract wsg from
- * @param feature The feature to load 
+ * @param feature The feature to load
  * @param dest The place to save the file into
  * @return bool True if it found a sprite, false otherwise
  */

--- a/main/utils/swadgesona.h
+++ b/main/utils/swadgesona.h
@@ -617,7 +617,8 @@ void loadSPSona(swadgesonaCore_t* sw);
 
 // Get indexes
 /**
- * @brief Copy the sprite and color at an index to a wsg_t. Please erase after use.
+ * @brief Copy the sprite and color at an index to a wsg_t. This function allocates memory for the wsg_t, please
+ * freeWsg() when done with image.
  *
  * @note Please note that there are probably some issues with this:
  * - Human ears are default, and will provide a "false" signal


### PR DESCRIPTION
## Description

Added the ability to grab a single image from a sona, in the correct colors

## Test Instructions

1. Uncomment lines 181-187 in sonaTest.c
2. Run the swadgesona test mode
3. Make sure a visible item is shown in all slots

## Ticket Links

None. Yell at Andy.

## Readiness Checklist

### Code Quality

- [x] I have run `make format` to format the changes
- [x] I have compiled the firmware and the changes have no warnings
- [x] I have compiled the emulator and the changes have no warnings
- [ ] I have run `make cppcheck` and checked that `cppcheck_result.txt` has no warnings for the changes
- [ ] I have added doxygen comments to any code used by more than one Swadge mode. This includes `/*! \file` comments with Design Philosophy, Usage, and Example sections for new headers.
- [ ] I have run `make docs` and checked that `doxy_warnings.txt` has no warnings for the new code
