### PR TITLE
Gamepad fixes

### DIFF
--- a/components/hdw-usb/include/hdw-usb.h
+++ b/components/hdw-usb/include/hdw-usb.h
@@ -92,12 +92,12 @@ typedef struct TU_ATTR_PACKED
 {
     uint16_t buttons; ///< Buttons mask for currently pressed buttons
     uint8_t hat;      ///< Buttons mask for currently pressed buttons in the DPad/hat
-    int8_t x;         ///< Delta x  movement of left analog-stick
-    int8_t y;         ///< Delta y  movement of left analog-stick
-    int8_t rx;        ///< Delta Rx movement of analog left trigger
-    int8_t ry;        ///< Delta Ry movement of analog right trigger
-    int8_t z;         ///< Delta z  movement of right analog-joystick
-    int8_t rz;        ///< Delta Rz movement of right analog-joystick
+    uint8_t x;         ///< Delta x  movement of left analog-stick
+    uint8_t y;         ///< Delta y  movement of left analog-stick
+    uint8_t rx;        ///< Delta Rx movement of analog left trigger
+    uint8_t ry;        ///< Delta Ry movement of analog right trigger
+    uint8_t z;         ///< Delta z  movement of right analog-joystick
+    uint8_t rz;        ///< Delta Rz movement of right analog-joystick
 } hid_gamepad_ns_report_t;
 
 //==============================================================================

--- a/emulator/src/emu_utils.c
+++ b/emulator/src/emu_utils.c
@@ -127,7 +127,7 @@ bool makeDirs(const char* path)
             cur++;
         }
 
-        char* next = strchr(cur, '/');
+        const char* next = strchr(cur, '/');
 
         if (next)
         {

--- a/main/modes/system/intro/introMode.c
+++ b/main/modes/system/intro/introMode.c
@@ -1303,13 +1303,11 @@ static void introDrawSwadgeImu(int64_t elapsedUs)
         vertices++;
     }
 
-    int lines = 0;
     for (i = 0; i < numBunnyLines(); i += 2)
     {
         int v1 = bunny_lines[i] * 3;
         int v2 = bunny_lines[i + 1] * 3;
         drawLineFast(bunny_verts_out[v1], bunny_verts_out[v1 + 1], bunny_verts_out[v2], bunny_verts_out[v2 + 1], c511);
-        lines++;
     }
 }
 

--- a/main/modes/test/accelTest/accelTest.c
+++ b/main/modes/test/accelTest/accelTest.c
@@ -287,7 +287,6 @@ static void accelDrawBunny(void)
         vertices++;
     }
 
-    int lines = 0;
     for (i = 0; i < numBunnyLines(); i += 2)
     {
         int v1    = bunny_lines[i] * 3;
@@ -298,7 +297,6 @@ static void accelDrawBunny(void)
         else if (col < 0)
             continue;
         drawLineFast(bunny_verts_out[v1], bunny_verts_out[v1 + 1], bunny_verts_out[v2], bunny_verts_out[v2 + 1], col);
-        lines++;
     }
 }
 

--- a/main/modes/utilities/gamepad/gamepad.c
+++ b/main/modes/utilities/gamepad/gamepad.c
@@ -607,6 +607,7 @@ void gamepadNsMainLoop(int64_t elapsedUs __attribute__((unused)))
         };
 
         // For each hat direction
+        uint8_t hatsDrawn = 0;
         for (uint8_t i = 0; i < ARRAY_SIZE(hatDirs); i++)
         {
             // The degree around the cluster
@@ -633,42 +634,42 @@ void gamepadNsMainLoop(int64_t elapsedUs __attribute__((unused)))
                     {
                         case GAMEPAD_HAT_UP:
                         {
-                            isPressed = (0 == gamepad->gpNsState.x) && (0 > gamepad->gpNsState.y);
+                            isPressed = (128 == gamepad->gpNsState.x) && (128 > gamepad->gpNsState.y);
                             break;
                         }
                         case GAMEPAD_HAT_UP_RIGHT:
                         {
-                            isPressed = (0 < gamepad->gpNsState.x) && (0 > gamepad->gpNsState.y);
+                            isPressed = (128 < gamepad->gpNsState.x) && (128 > gamepad->gpNsState.y);
                             break;
                         }
                         case GAMEPAD_HAT_RIGHT:
                         {
-                            isPressed = (0 < gamepad->gpNsState.x) && (0 == gamepad->gpNsState.y);
+                            isPressed = (128 < gamepad->gpNsState.x) && (128 == gamepad->gpNsState.y);
                             break;
                         }
                         case GAMEPAD_HAT_DOWN_RIGHT:
                         {
-                            isPressed = (0 < gamepad->gpNsState.x) && (0 < gamepad->gpNsState.y);
+                            isPressed = (128 < gamepad->gpNsState.x) && (128 < gamepad->gpNsState.y);
                             break;
                         }
                         case GAMEPAD_HAT_DOWN:
                         {
-                            isPressed = (0 == gamepad->gpNsState.x) && (0 < gamepad->gpNsState.y);
+                            isPressed = (128 == gamepad->gpNsState.x) && (128 < gamepad->gpNsState.y);
                             break;
                         }
                         case GAMEPAD_HAT_DOWN_LEFT:
                         {
-                            isPressed = (0 > gamepad->gpNsState.x) && (0 < gamepad->gpNsState.y);
+                            isPressed = (128 > gamepad->gpNsState.x) && (128 < gamepad->gpNsState.y);
                             break;
                         }
                         case GAMEPAD_HAT_LEFT:
                         {
-                            isPressed = (0 > gamepad->gpNsState.x) && (0 == gamepad->gpNsState.y);
+                            isPressed = (128 > gamepad->gpNsState.x) && (128 == gamepad->gpNsState.y);
                             break;
                         }
                         case GAMEPAD_HAT_UP_LEFT:
                         {
-                            isPressed = (0 > gamepad->gpNsState.x) && (0 > gamepad->gpNsState.y);
+                            isPressed = (128 > gamepad->gpNsState.x) && (128 > gamepad->gpNsState.y);
                             break;
                         }
                     }
@@ -676,6 +677,10 @@ void gamepadNsMainLoop(int64_t elapsedUs __attribute__((unused)))
                 }
             }
 
+            if (isPressed)
+            {
+                hatsDrawn |= (1 << i);
+            }
             drawFunc = isPressed ? &drawCircleFilled : &drawCircle;
             drawFunc(xc, yc, DPAD_BTN_RADIUS, c551);
         }
@@ -754,14 +759,11 @@ void gamepadNsMainLoop(int64_t elapsedUs __attribute__((unused)))
         uint8_t bitmap[EYE_LED_H][EYE_LED_W] = {0};
         uint8_t btnBrightness                = 0;
 
-        if ((gamepad->gpNsState.hat == gamepad->previousHat)
-            && (gamepad->gpNsState.buttons == gamepad->previousButtons))
+        // Only draw when there's a change
+        if (hatsDrawn != gamepad->previousHatsDrawn || gamepad->gpNsState.buttons != gamepad->previousButtons)
         {
-            // Skip eye update if no change
-            // break;
-        }
-        else
-        {
+            gamepad->previousHatsDrawn = hatsDrawn;
+
             bitmap[5][0]  = (gamepad->gpNsState.buttons & GAMEPAD_NS_BUTTON_TL) ? EYE_LED_BRIGHT : 0;
             bitmap[5][5]  = (gamepad->gpNsState.buttons & GAMEPAD_NS_BUTTON_TL2) ? EYE_LED_BRIGHT : 0;
             bitmap[5][6]  = (gamepad->gpNsState.buttons & GAMEPAD_NS_BUTTON_TR2) ? EYE_LED_BRIGHT : 0;
@@ -796,60 +798,44 @@ void gamepadNsMainLoop(int64_t elapsedUs __attribute__((unused)))
             bitmap[2][6]  = btnBrightness;
             bitmap[2][7]  = btnBrightness;
 
-            switch (gamepad->gpNsState.hat)
+            if (hatsDrawn
+                & ((1 << (GAMEPAD_NS_HAT_UP - 1)) | (1 << (GAMEPAD_NS_HAT_UP_LEFT - 1))
+                   | (1 << (GAMEPAD_NS_HAT_UP_RIGHT - 1))))
             {
-                case GAMEPAD_NS_HAT_UP:
-                case GAMEPAD_NS_HAT_UP_LEFT:
-                case GAMEPAD_NS_HAT_UP_RIGHT:
-                    bitmap[5][2] = EYE_LED_BRIGHT;
-                    bitmap[5][3] = EYE_LED_BRIGHT;
-                    bitmap[4][2] = EYE_LED_BRIGHT;
-                    bitmap[4][3] = EYE_LED_BRIGHT;
-                    // fallthrough
-                default:
-                    break;
+                bitmap[5][2] = EYE_LED_BRIGHT;
+                bitmap[5][3] = EYE_LED_BRIGHT;
+                bitmap[4][2] = EYE_LED_BRIGHT;
+                bitmap[4][3] = EYE_LED_BRIGHT;
             }
 
-            switch (gamepad->gpNsState.hat)
+            if (hatsDrawn
+                & ((1 << (GAMEPAD_NS_HAT_RIGHT - 1)) | (1 << (GAMEPAD_NS_HAT_UP_RIGHT - 1))
+                   | (1 << (GAMEPAD_NS_HAT_DOWN_RIGHT - 1))))
             {
-                case GAMEPAD_NS_HAT_RIGHT:
-                case GAMEPAD_NS_HAT_UP_RIGHT:
-                case GAMEPAD_NS_HAT_DOWN_RIGHT:
-                    bitmap[3][4] = EYE_LED_BRIGHT;
-                    bitmap[3][5] = EYE_LED_BRIGHT;
-                    bitmap[2][4] = EYE_LED_BRIGHT;
-                    bitmap[2][5] = EYE_LED_BRIGHT;
-                    // fallthrough
-                default:
-                    break;
+                bitmap[3][4] = EYE_LED_BRIGHT;
+                bitmap[3][5] = EYE_LED_BRIGHT;
+                bitmap[2][4] = EYE_LED_BRIGHT;
+                bitmap[2][5] = EYE_LED_BRIGHT;
             }
 
-            switch (gamepad->gpNsState.hat)
+            if (hatsDrawn
+                & ((1 << (GAMEPAD_NS_HAT_DOWN - 1)) | (1 << (GAMEPAD_NS_HAT_DOWN_RIGHT - 1))
+                   | (1 << (GAMEPAD_NS_HAT_DOWN_LEFT - 1))))
             {
-                case GAMEPAD_NS_HAT_DOWN:
-                case GAMEPAD_NS_HAT_DOWN_RIGHT:
-                case GAMEPAD_NS_HAT_DOWN_LEFT:
-                    bitmap[1][2] = EYE_LED_BRIGHT;
-                    bitmap[1][3] = EYE_LED_BRIGHT;
-                    bitmap[0][2] = EYE_LED_BRIGHT;
-                    bitmap[0][3] = EYE_LED_BRIGHT;
-                    // fallthrough
-                default:
-                    break;
+                bitmap[1][2] = EYE_LED_BRIGHT;
+                bitmap[1][3] = EYE_LED_BRIGHT;
+                bitmap[0][2] = EYE_LED_BRIGHT;
+                bitmap[0][3] = EYE_LED_BRIGHT;
             }
 
-            switch (gamepad->gpNsState.hat)
+            if (hatsDrawn
+                & ((1 << (GAMEPAD_NS_HAT_LEFT - 1)) | (1 << (GAMEPAD_NS_HAT_UP_LEFT - 1))
+                   | (1 << (GAMEPAD_NS_HAT_DOWN_LEFT - 1))))
             {
-                case GAMEPAD_NS_HAT_LEFT:
-                case GAMEPAD_NS_HAT_UP_LEFT:
-                case GAMEPAD_NS_HAT_DOWN_LEFT:
-                    bitmap[3][0] = EYE_LED_BRIGHT;
-                    bitmap[3][1] = EYE_LED_BRIGHT;
-                    bitmap[2][0] = EYE_LED_BRIGHT;
-                    bitmap[2][1] = EYE_LED_BRIGHT;
-                    // fallthrough
-                default:
-                    break;
+                bitmap[3][0] = EYE_LED_BRIGHT;
+                bitmap[3][1] = EYE_LED_BRIGHT;
+                bitmap[2][0] = EYE_LED_BRIGHT;
+                bitmap[2][1] = EYE_LED_BRIGHT;
             }
 
             // Write and select the bitmap to an unused slot

--- a/main/modes/utilities/gamepad/gamepad.c
+++ b/main/modes/utilities/gamepad/gamepad.c
@@ -177,7 +177,7 @@ swadgeMode_t gamepadMode = {
 };
 
 // const hid_gamepad_button_bm_t touchMap[] = {
-//     GAMEPAD_BUTTON_C, GAMEPAD_BUTTON_X, GAMEPAD_BUTTON_Y, GAMEPAD_BUTTON_Z, GAMEPAD_BUTTON_TL,
+//     GAMEPAD_BUTTON_C, GAMEPAD_BUTTON_X, GAMEPAD_BUTTON_C, GAMEPAD_BUTTON_10, GAMEPAD_BUTTON_4,
 // };
 
 // const hid_gamepad_button_bm_t touchMapNs[] = {
@@ -880,26 +880,26 @@ void gamepadGenericMainLoop(int64_t elapsedUs __attribute__((unused)))
         }
 
         // Select button
-        drawFunc = (gamepad->gpState.buttons & GAMEPAD_BUTTON_SELECT) ? &drawCircleFilled : &drawCircle;
+        drawFunc = (gamepad->gpState.buttons & GAMEPAD_BUTTON_TL2) ? &drawCircleFilled : &drawCircle;
 
         int16_t x = (TFT_WIDTH / 2) - START_BTN_RADIUS - START_BTN_SEP;
         int16_t y = ((3 * TFT_WIDTH) / 4) - START_BTN_Y_OFF + Y_OFF;
         drawFunc(x, y, START_BTN_RADIUS, c333);
 
         // Start button
-        drawFunc = (gamepad->gpState.buttons & GAMEPAD_BUTTON_START) ? &drawCircleFilled : &drawCircle;
+        drawFunc = (gamepad->gpState.buttons & GAMEPAD_BUTTON_TR2) ? &drawCircleFilled : &drawCircle;
 
         x = (TFT_WIDTH / 2) + START_BTN_RADIUS + START_BTN_SEP;
         drawFunc(x, y, START_BTN_RADIUS, c333);
 
         // Button A
-        drawFunc = (gamepad->gpState.buttons & GAMEPAD_BUTTON_A) ? &drawCircleFilled : &drawCircle;
+        drawFunc = (gamepad->gpState.buttons & GAMEPAD_BUTTON_B) ? &drawCircleFilled : &drawCircle;
 
         drawFunc(((3 * TFT_WIDTH) / 4) + AB_BTN_RADIUS + AB_BTN_SEP,
                  (TFT_HEIGHT / 4) - AB_BTN_Y_SEP - AB_BTN_Y_OFF + Y_OFF, AB_BTN_RADIUS, c243);
 
         // Button B
-        drawFunc = (gamepad->gpState.buttons & GAMEPAD_BUTTON_B) ? &drawCircleFilled : &drawCircle;
+        drawFunc = (gamepad->gpState.buttons & GAMEPAD_BUTTON_A) ? &drawCircleFilled : &drawCircle;
 
         drawFunc(((3 * TFT_WIDTH) / 4) - AB_BTN_RADIUS - AB_BTN_SEP,
                  (TFT_HEIGHT / 4) + AB_BTN_Y_SEP - AB_BTN_Y_OFF + Y_OFF, AB_BTN_RADIUS, c401);
@@ -918,7 +918,7 @@ void gamepadGenericMainLoop(int64_t elapsedUs __attribute__((unused)))
             intensity = 0;
         }
 
-        gamepadTouch_t touchSetting = getGamepadNsTouchSetting();
+        gamepadTouch_t touchSetting = getGamepadPcTouchSetting();
         switch (touchSetting)
         {
             default:
@@ -943,13 +943,13 @@ void gamepadGenericMainLoop(int64_t elapsedUs __attribute__((unused)))
         {
             // Declare variables to receive acceleration
             int16_t a_x, a_y, a_z;
-            // Get the current acceleration
+            // Get the current acceleration and map it to right stick
             if (ESP_OK == accelIntegrate() && ESP_OK == accelGetOrientVec(&a_x, &a_y, &a_z))
             {
                 // Values are roughly -256 to 256, so divide, clamp, and save
-                gamepad->gpState.rx = CLAMP((a_x) / 2, -128, 127);
-                gamepad->gpState.ry = CLAMP((a_y) / 2, -128, 127);
-                gamepad->gpState.rz = CLAMP((a_z) / 2, -128, 127);
+                gamepad->gpState.z = -CLAMP((a_x) / 2, -128, 127);
+                gamepad->gpState.rx = CLAMP((a_y) / 2, -128, 127);
+                //gamepad->gpState.rz = CLAMP((a_z) / 2, -128, 127); //Nothing to map this to!
             }
 
             // Set up drawing accel bars
@@ -981,15 +981,15 @@ void gamepadGenericMainLoop(int64_t elapsedUs __attribute__((unused)))
         }
         else
         {
-            bitmap[5][0]  = (gamepad->gpState.buttons & GAMEPAD_BUTTON_TL) ? EYE_LED_BRIGHT : 0;
-            bitmap[5][5]  = (gamepad->gpState.buttons & GAMEPAD_BUTTON_TL2) ? EYE_LED_BRIGHT : 0;
-            bitmap[5][6]  = (gamepad->gpState.buttons & GAMEPAD_BUTTON_TR2) ? EYE_LED_BRIGHT : 0;
-            bitmap[5][11] = (gamepad->gpState.buttons & GAMEPAD_BUTTON_TR) ? EYE_LED_BRIGHT : 0;
+            bitmap[5][0]  = (gamepad->gpState.buttons & GAMEPAD_BUTTON_4) ? EYE_LED_BRIGHT : 0;
+            bitmap[5][5]  = (gamepad->gpState.buttons & GAMEPAD_BUTTON_TL) ? EYE_LED_BRIGHT : 0;
+            bitmap[5][6]  = (gamepad->gpState.buttons & GAMEPAD_BUTTON_TR) ? EYE_LED_BRIGHT : 0;
+            bitmap[5][11] = (gamepad->gpState.buttons & GAMEPAD_BUTTON_5) ? EYE_LED_BRIGHT : 0;
 
-            bitmap[0][0]  = (gamepad->gpState.buttons & GAMEPAD_BUTTON_Z) ? EYE_LED_BRIGHT : 0;
-            bitmap[0][5]  = (gamepad->gpState.buttons & GAMEPAD_BUTTON_SELECT) ? EYE_LED_BRIGHT : 0;
-            bitmap[0][6]  = (gamepad->gpState.buttons & GAMEPAD_BUTTON_START) ? EYE_LED_BRIGHT : 0;
-            bitmap[0][11] = (gamepad->gpState.buttons & GAMEPAD_BUTTON_MODE) ? EYE_LED_BRIGHT : 0;
+            bitmap[0][0]  = (gamepad->gpState.buttons & GAMEPAD_BUTTON_10) ? EYE_LED_BRIGHT : 0;
+            bitmap[0][5]  = (gamepad->gpState.buttons & GAMEPAD_BUTTON_TL2) ? EYE_LED_BRIGHT : 0;
+            bitmap[0][6]  = (gamepad->gpState.buttons & GAMEPAD_BUTTON_TR2) ? EYE_LED_BRIGHT : 0;
+            bitmap[0][11] = (gamepad->gpState.buttons & GAMEPAD_BUTTON_11) ? EYE_LED_BRIGHT : 0;
 
             btnBrightness = (gamepad->gpState.buttons & GAMEPAD_BUTTON_X) ? EYE_LED_BRIGHT : 0;
             bitmap[5][8]  = btnBrightness;
@@ -997,25 +997,49 @@ void gamepadGenericMainLoop(int64_t elapsedUs __attribute__((unused)))
             bitmap[4][8]  = btnBrightness;
             bitmap[4][9]  = btnBrightness;
 
-            btnBrightness = (gamepad->gpState.buttons & GAMEPAD_BUTTON_A) ? EYE_LED_BRIGHT : 0;
+            btnBrightness = (gamepad->gpState.buttons & GAMEPAD_BUTTON_B) ? EYE_LED_BRIGHT : 0;
             bitmap[3][10] = btnBrightness;
             bitmap[3][11] = btnBrightness;
             bitmap[2][10] = btnBrightness;
             bitmap[2][11] = btnBrightness;
 
-            btnBrightness = (gamepad->gpState.buttons & GAMEPAD_BUTTON_B) ? EYE_LED_BRIGHT : 0;
+            btnBrightness = (gamepad->gpState.buttons & GAMEPAD_BUTTON_A) ? EYE_LED_BRIGHT : 0;
             bitmap[1][8]  = btnBrightness;
             bitmap[1][9]  = btnBrightness;
             bitmap[0][8]  = btnBrightness;
             bitmap[0][9]  = btnBrightness;
 
-            btnBrightness = (gamepad->gpState.buttons & GAMEPAD_BUTTON_Y) ? EYE_LED_BRIGHT : 0;
+            btnBrightness = (gamepad->gpState.buttons & GAMEPAD_BUTTON_C) ? EYE_LED_BRIGHT : 0;
             bitmap[3][6]  = btnBrightness;
             bitmap[3][7]  = btnBrightness;
             bitmap[2][6]  = btnBrightness;
             bitmap[2][7]  = btnBrightness;
 
-            switch (gamepad->gpState.hat)
+            btnBrightness = (gamepad->gpState.buttons & GAMEPAD_BUTTON_12) ? EYE_LED_BRIGHT : 0;
+            bitmap[5][2] = btnBrightness;
+            bitmap[5][3] = btnBrightness;
+            bitmap[4][2] = btnBrightness;
+            bitmap[4][3] = btnBrightness;
+
+            btnBrightness = (gamepad->gpState.buttons & GAMEPAD_BUTTON_15) ? EYE_LED_BRIGHT : 0;
+            bitmap[3][4] = btnBrightness;
+            bitmap[3][5] = btnBrightness;
+            bitmap[2][4] = btnBrightness;
+            bitmap[2][5] = btnBrightness;
+
+            btnBrightness = (gamepad->gpState.buttons & GAMEPAD_BUTTON_13) ? EYE_LED_BRIGHT : 0;
+            bitmap[1][2] = btnBrightness;
+            bitmap[1][3] = btnBrightness;
+            bitmap[0][2] = btnBrightness;
+            bitmap[0][3] = btnBrightness;
+
+            btnBrightness = (gamepad->gpState.buttons & GAMEPAD_BUTTON_14) ? EYE_LED_BRIGHT : 0;
+            bitmap[3][0] = btnBrightness;
+            bitmap[3][1] = btnBrightness;
+            bitmap[2][0] = btnBrightness;
+            bitmap[2][1] = btnBrightness;
+
+            /*switch (gamepad->gpState.hat)
             {
                 case GAMEPAD_HAT_UP:
                 case GAMEPAD_HAT_UP_LEFT:
@@ -1069,7 +1093,7 @@ void gamepadGenericMainLoop(int64_t elapsedUs __attribute__((unused)))
                     // fallthrough
                 default:
                     break;
-            }
+            }*/
 
             // Write and select the bitmap to an unused slot
             ch32v003WriteBitmap(gamepad->bmpSlot, bitmap);
@@ -1273,43 +1297,43 @@ void gamepadGenericButtonCb(buttonEvt_t* evt)
     }
 
     // Build a list of all independent buttons held down
-    gamepad->gpState.buttons &= ~(GAMEPAD_BUTTON_A | GAMEPAD_BUTTON_B | GAMEPAD_BUTTON_START | GAMEPAD_BUTTON_SELECT
-                                  | GAMEPAD_BUTTON_MODE | GAMEPAD_BUTTON_Z | GAMEPAD_BUTTON_X | GAMEPAD_BUTTON_Y
-                                  | GAMEPAD_BUTTON_TL | GAMEPAD_BUTTON_TR | GAMEPAD_BUTTON_TL2 | GAMEPAD_BUTTON_TR2);
+    gamepad->gpState.buttons &= ~(GAMEPAD_BUTTON_B | GAMEPAD_BUTTON_A | GAMEPAD_BUTTON_TR2 | GAMEPAD_BUTTON_TL2
+                                  | GAMEPAD_BUTTON_11 | GAMEPAD_BUTTON_10 | GAMEPAD_BUTTON_X | GAMEPAD_BUTTON_C
+                                  | GAMEPAD_BUTTON_4 | GAMEPAD_BUTTON_5 | GAMEPAD_BUTTON_TL | GAMEPAD_BUTTON_TR | GAMEPAD_BUTTON_12 | GAMEPAD_BUTTON_13 | GAMEPAD_BUTTON_14 | GAMEPAD_BUTTON_15);
 
     if (evt->state & PB_A)
     {
-        gamepad->gpState.buttons |= GAMEPAD_BUTTON_A;
+        gamepad->gpState.buttons |= GAMEPAD_BUTTON_B;
     }
     if (evt->state & PB_B)
     {
-        gamepad->gpState.buttons |= GAMEPAD_BUTTON_B;
+        gamepad->gpState.buttons |= GAMEPAD_BUTTON_A;
     }
     if (evt->state & PB_START)
     {
         if (evt->state & PB_DOWN)
         {
-            gamepad->gpState.buttons |= GAMEPAD_BUTTON_MODE;
+            gamepad->gpState.buttons |= GAMEPAD_BUTTON_11;
         }
         else
         {
-            gamepad->gpState.buttons |= GAMEPAD_BUTTON_START;
+            gamepad->gpState.buttons |= GAMEPAD_BUTTON_TR2;
         }
     }
     if (evt->state & PB_SELECT)
     {
         if (evt->state & PB_DOWN)
         {
-            gamepad->gpState.buttons |= GAMEPAD_BUTTON_Z;
+            gamepad->gpState.buttons |= GAMEPAD_BUTTON_10;
         }
         else
         {
-            gamepad->gpState.buttons |= GAMEPAD_BUTTON_SELECT;
+            gamepad->gpState.buttons |= GAMEPAD_BUTTON_TL2;
         }
     }
 
     // Figure out which way the D-Pad is pointing
-    switch (getGamepadNsDpadSetting())
+    switch (getGamepadPcDpadSetting())
     {
         case GAMEPAD_DPAD_NORMAL_SETTING:
         default:
@@ -1317,41 +1341,49 @@ void gamepadGenericButtonCb(buttonEvt_t* evt)
             gamepad->gpState.hat = GAMEPAD_HAT_CENTERED;
             if (evt->state & PB_UP)
             {
-                if (evt->state & PB_RIGHT)
+                /*if (evt->state & PB_RIGHT)
                 {
                     gamepad->gpState.hat = GAMEPAD_HAT_UP_RIGHT;
+                    gamepad->gpState.buttons |= GAMEPAD_BUTTON_15;
                 }
                 else if (evt->state & PB_LEFT)
                 {
                     gamepad->gpState.hat = GAMEPAD_HAT_UP_LEFT;
+                    gamepad->gpState.buttons |= GAMEPAD_BUTTON_14;
                 }
                 else
-                {
+                {*/
                     gamepad->gpState.hat = GAMEPAD_HAT_UP;
-                }
+                    gamepad->gpState.buttons |= GAMEPAD_BUTTON_12;
+                //}
             }
-            else if (evt->state & PB_DOWN)
+            /*else*/ if (evt->state & PB_DOWN)
             {
-                if (evt->state & PB_RIGHT)
+                /*if (evt->state & PB_RIGHT)
                 {
                     gamepad->gpState.hat = GAMEPAD_HAT_DOWN_RIGHT;
+                    gamepad->gpState.buttons |= GAMEPAD_BUTTON_15;
                 }
                 else if (evt->state & PB_LEFT)
                 {
                     gamepad->gpState.hat = GAMEPAD_HAT_DOWN_LEFT;
+                    gamepad->gpState.buttons |= GAMEPAD_BUTTON_14;
                 }
                 else
-                {
+                {*/
                     gamepad->gpState.hat = GAMEPAD_HAT_DOWN;
-                }
+                    gamepad->gpState.buttons |= GAMEPAD_BUTTON_13;
+                //}
             }
-            else if (evt->state & PB_RIGHT)
+            if (evt->state & PB_RIGHT)
             {
                 gamepad->gpState.hat = GAMEPAD_HAT_RIGHT;
+                gamepad->gpState.buttons |= GAMEPAD_BUTTON_15;
             }
-            else if (evt->state & PB_LEFT)
+            if (evt->state & PB_LEFT)
             {
                 gamepad->gpState.hat = GAMEPAD_HAT_LEFT;
+                gamepad->gpState.buttons |= GAMEPAD_BUTTON_14;
             }
             break;
         }
@@ -1359,7 +1391,7 @@ void gamepadGenericButtonCb(buttonEvt_t* evt)
         {
             gamepad->gpState.x = 0;
             gamepad->gpState.y = 0;
-            int32_t intensity  = getGamepadNsDpadStickIntensitySetting();
+            int32_t intensity  = getGamepadPcDpadStickIntensitySetting();
 
             if (evt->state & PB_UP)
             {
@@ -1381,25 +1413,25 @@ void gamepadGenericButtonCb(buttonEvt_t* evt)
         }
         case GAMEPAD_DPAD_R_STICK_SETTING:
         {
+            gamepad->gpState.z = 0;
             gamepad->gpState.rx = 0;
-            gamepad->gpState.ry = 0;
-            int32_t intensity   = getGamepadNsDpadStickIntensitySetting();
+            int32_t intensity   = getGamepadPcDpadStickIntensitySetting();
 
             if (evt->state & PB_UP)
             {
-                gamepad->gpState.ry = -intensity;
+                gamepad->gpState.rx = -intensity;
             }
             if (evt->state & PB_DOWN)
             {
-                gamepad->gpState.ry = intensity;
+                gamepad->gpState.rx = intensity;
             }
             if (evt->state & PB_RIGHT)
             {
-                gamepad->gpState.rx = intensity;
+                gamepad->gpState.z = intensity;
             }
             if (evt->state & PB_LEFT)
             {
-                gamepad->gpState.rx = -intensity;
+                gamepad->gpState.z = -intensity;
             }
             break;
         }
@@ -1503,21 +1535,21 @@ void gamepadNsReportStateToHost(void)
             }
             case GAMEPAD_TOUCH_L_STICK_SETTING:
             {
-                if (touched || getGamepadNsTouchStickRecenterSetting())
+                if (touched || getGamepadPcTouchStickRecenterSetting())
                 {
                     gamepad->gpNsState.x = x;
                     gamepad->gpNsState.y = y;
-                    gamepad->gpNsState.z = z;
+                    //gamepad->gpNsState.z = z;
                 }
                 break;
             }
             case GAMEPAD_TOUCH_R_STICK_SETTING:
             {
-                if (touched || getGamepadNsTouchStickRecenterSetting())
+                if (touched || getGamepadPcTouchStickRecenterSetting())
                 {
-                    gamepad->gpNsState.rx = x;
-                    gamepad->gpNsState.ry = y;
-                    gamepad->gpNsState.rz = z;
+                    gamepad->gpNsState.z = x;
+                    gamepad->gpNsState.rx = y;
+                    //gamepad->gpNsState.rz = z;
                 }
                 break;
             }
@@ -1557,13 +1589,13 @@ void gamepadGenericReportStateToHost(void)
             z = 0;
         }
 
-        gamepadTouch_t touchSetting = getGamepadNsTouchSetting();
+        gamepadTouch_t touchSetting = getGamepadPcTouchSetting();
         switch (touchSetting)
         {
             case GAMEPAD_TOUCH_MORE_BUTTONS_SETTING:
             {
-                gamepad->gpState.buttons &= ~(GAMEPAD_BUTTON_X | GAMEPAD_BUTTON_Y | GAMEPAD_BUTTON_TL
-                                              | GAMEPAD_BUTTON_TR | GAMEPAD_BUTTON_TL2 | GAMEPAD_BUTTON_TR2);
+                gamepad->gpState.buttons &= ~(GAMEPAD_BUTTON_X | GAMEPAD_BUTTON_C | GAMEPAD_BUTTON_4
+                                              | GAMEPAD_BUTTON_5 | GAMEPAD_BUTTON_TL | GAMEPAD_BUTTON_TR);
                 if (!touched)
                 {
                     break;
@@ -1584,39 +1616,39 @@ void gamepadGenericReportStateToHost(void)
                     }
                     case TB_UP_RIGHT:
                     {
-                        gamepad->gpState.buttons |= GAMEPAD_BUTTON_TR;
+                        gamepad->gpState.buttons |= GAMEPAD_BUTTON_5;
                         break;
                     }
                     case TB_UP:
                     {
-                        gamepad->gpState.buttons |= GAMEPAD_BUTTON_TR;
-                        gamepad->gpState.buttons |= GAMEPAD_BUTTON_TL;
+                        gamepad->gpState.buttons |= GAMEPAD_BUTTON_5;
+                        gamepad->gpState.buttons |= GAMEPAD_BUTTON_4;
                         break;
                     }
                     case TB_UP_LEFT:
                     {
-                        gamepad->gpState.buttons |= GAMEPAD_BUTTON_TL;
+                        gamepad->gpState.buttons |= GAMEPAD_BUTTON_4;
                         break;
                     }
                     case TB_LEFT:
                     {
-                        gamepad->gpState.buttons |= GAMEPAD_BUTTON_Y;
+                        gamepad->gpState.buttons |= GAMEPAD_BUTTON_C;
                         break;
                     }
                     case TB_DOWN_LEFT:
                     {
-                        gamepad->gpState.buttons |= GAMEPAD_BUTTON_TL2;
+                        gamepad->gpState.buttons |= GAMEPAD_BUTTON_TL;
                         break;
                     }
                     case TB_DOWN:
                     {
-                        gamepad->gpState.buttons |= GAMEPAD_BUTTON_TL2;
-                        gamepad->gpState.buttons |= GAMEPAD_BUTTON_TR2;
+                        gamepad->gpState.buttons |= GAMEPAD_BUTTON_TL;
+                        gamepad->gpState.buttons |= GAMEPAD_BUTTON_TR;
                         break;
                     }
                     case TB_DOWN_RIGHT:
                     {
-                        gamepad->gpState.buttons |= GAMEPAD_BUTTON_TR2;
+                        gamepad->gpState.buttons |= GAMEPAD_BUTTON_TR;
                         break;
                     }
                 }
@@ -1624,21 +1656,21 @@ void gamepadGenericReportStateToHost(void)
             }
             case GAMEPAD_TOUCH_L_STICK_SETTING:
             {
-                if (touched || getGamepadNsTouchStickRecenterSetting())
+                if (touched || getGamepadPcTouchStickRecenterSetting())
                 {
                     gamepad->gpState.x = x;
                     gamepad->gpState.y = y;
-                    gamepad->gpState.z = z;
+                    //gamepad->gpState.z = z;
                 }
                 break;
             }
             case GAMEPAD_TOUCH_R_STICK_SETTING:
             {
-                if (touched || getGamepadNsTouchStickRecenterSetting())
+                if (touched || getGamepadPcTouchStickRecenterSetting())
                 {
-                    gamepad->gpState.rx = x;
-                    gamepad->gpState.ry = y;
-                    gamepad->gpState.rz = z;
+                    gamepad->gpState.z = x;
+                    gamepad->gpState.rx = y;
+                    //gamepad->gpState.rx = z;
                 }
                 break;
             }
@@ -1646,7 +1678,7 @@ void gamepadGenericReportStateToHost(void)
 
         // Send the state over USB
         tud_hid_gamepad_report(HID_ITF_PROTOCOL_NONE, gamepad->gpState.x, gamepad->gpState.y, gamepad->gpState.z,
-                               gamepad->gpState.rx, gamepad->gpState.ry, gamepad->gpState.rz, gamepad->gpState.hat,
+                               gamepad->gpState.rx, gamepad->gpState.ry, gamepad->gpState.rz, 0,
                                gamepad->gpState.buttons);
     }
 }

--- a/main/modes/utilities/gamepad/gamepad.c
+++ b/main/modes/utilities/gamepad/gamepad.c
@@ -1456,25 +1456,25 @@ void gamepadGenericButtonCb(buttonEvt_t* evt)
         }
         case GAMEPAD_DPAD_R_STICK_SETTING:
         {
+            gamepad->gpState.z = 0;
             gamepad->gpState.rx = 0;
-            gamepad->gpState.ry = 0;
             int32_t intensity   = getGamepadPcDpadStickIntensitySetting();
 
             if (evt->state & PB_UP)
             {
-                gamepad->gpState.ry = -intensity;
+                gamepad->gpState.rx = -intensity;
             }
             if (evt->state & PB_DOWN)
             {
-                gamepad->gpState.ry = intensity;
+                gamepad->gpState.rx = intensity;
             }
             if (evt->state & PB_RIGHT)
             {
-                gamepad->gpState.rx = intensity;
+                gamepad->gpState.z = intensity;
             }
             if (evt->state & PB_LEFT)
             {
-                gamepad->gpState.rx = -intensity;
+                gamepad->gpState.z = -intensity;
             }
             break;
         }
@@ -1587,8 +1587,8 @@ void gamepadNsReportStateToHost(void)
             {
                 if (touched || getGamepadPcTouchStickRecenterSetting())
                 {
-                    gamepad->gpNsState.rx = x;
-                    gamepad->gpNsState.ry = y;
+                    gamepad->gpNsState.z = x;
+                    gamepad->gpNsState.rx = y;
                 }
                 break;
             }
@@ -1703,8 +1703,8 @@ void gamepadGenericReportStateToHost(void)
             {
                 if (touched || getGamepadPcTouchStickRecenterSetting())
                 {
-                    gamepad->gpState.rx = x;
-                    gamepad->gpState.ry = y;
+                    gamepad->gpState.z = x;
+                    gamepad->gpState.rx = y;
                 }
                 break;
             }

--- a/main/modes/utilities/gamepad/gamepad.c
+++ b/main/modes/utilities/gamepad/gamepad.c
@@ -1456,25 +1456,25 @@ void gamepadGenericButtonCb(buttonEvt_t* evt)
         }
         case GAMEPAD_DPAD_R_STICK_SETTING:
         {
-            gamepad->gpState.z = 0;
             gamepad->gpState.rx = 0;
+            gamepad->gpState.ry = 0;
             int32_t intensity   = getGamepadPcDpadStickIntensitySetting();
 
             if (evt->state & PB_UP)
             {
-                gamepad->gpState.rx = -intensity;
+                gamepad->gpState.ry = -intensity;
             }
             if (evt->state & PB_DOWN)
             {
-                gamepad->gpState.rx = intensity;
+                gamepad->gpState.ry = intensity;
             }
             if (evt->state & PB_RIGHT)
             {
-                gamepad->gpState.z = intensity;
+                gamepad->gpState.rx = intensity;
             }
             if (evt->state & PB_LEFT)
             {
-                gamepad->gpState.z = -intensity;
+                gamepad->gpState.rx = -intensity;
             }
             break;
         }
@@ -1703,8 +1703,8 @@ void gamepadGenericReportStateToHost(void)
             {
                 if (touched || getGamepadPcTouchStickRecenterSetting())
                 {
-                    gamepad->gpState.z = x;
-                    gamepad->gpState.rx = y;
+                    gamepad->gpState.rx = x;
+                    gamepad->gpState.ry = y;
                 }
                 break;
             }

--- a/main/modes/utilities/gamepad/gamepad.c
+++ b/main/modes/utilities/gamepad/gamepad.c
@@ -1576,7 +1576,7 @@ void gamepadNsReportStateToHost(void)
             }
             case GAMEPAD_TOUCH_L_STICK_SETTING:
             {
-                if (touched || getGamepadPcTouchStickRecenterSetting())
+                if (touched || getGamepadNsTouchStickRecenterSetting())
                 {
                     gamepad->gpNsState.x = x;
                     gamepad->gpNsState.y = y;
@@ -1585,10 +1585,10 @@ void gamepadNsReportStateToHost(void)
             }
             case GAMEPAD_TOUCH_R_STICK_SETTING:
             {
-                if (touched || getGamepadPcTouchStickRecenterSetting())
+                if (touched || getGamepadNsTouchStickRecenterSetting())
                 {
-                    gamepad->gpNsState.z = x;
-                    gamepad->gpNsState.rx = y;
+                    gamepad->gpNsState.rx = x;
+                    gamepad->gpNsState.ry = y;
                 }
                 break;
             }

--- a/main/modes/utilities/gamepad/gamepad.c
+++ b/main/modes/utilities/gamepad/gamepad.c
@@ -44,7 +44,7 @@
 #define TOUCHPAD_Y_OFF 8
 #define TOUCHPAD_X_OFF 10
 
-#define GP_NS_CENTERED -128
+#define GP_NS_CENTERED 128
 
 //==============================================================================
 // Enums

--- a/main/modes/utilities/gamepad/gamepad.c
+++ b/main/modes/utilities/gamepad/gamepad.c
@@ -1,3 +1,47 @@
+/**
+ * @file gamepad.c
+ *
+ * There is a lot of confusion about how PC gamepad mappings work.
+ *
+ * As of writing, tinyusb's hid.h says this:
+ *
+ * \code{.c}
+ * typedef struct TU_ATTR_PACKED
+ * {
+ *   int8_t  x;         ///< Delta x  movement of left analog-stick
+ *   int8_t  y;         ///< Delta y  movement of left analog-stick
+ *   int8_t  z;         ///< Delta z  movement of right analog-joystick
+ *   int8_t  rz;        ///< Delta Rz movement of right analog-joystick
+ *   int8_t  rx;        ///< Delta Rx movement of analog left trigger
+ *   int8_t  ry;        ///< Delta Ry movement of analog right trigger
+ *   uint8_t hat;       ///< Buttons mask for currently pressed buttons in the DPad/hat
+ *   uint32_t buttons;  ///< Buttons mask for currently pressed buttons
+ * } hid_gamepad_report_t;
+ * \endcode
+ *
+ * These comments are incorrect, and I suspect it's because the bytes are
+ * ordered (rz, rx, ry) rather than (rx, ry, rz). What it should be is:
+ *
+ * | Axis | Description | Struct Byte |
+ * |------|-------------|-------------|
+ * | 0    | L Stick X   | x           |
+ * | 1    | L Stick Y   | y           |
+ * | 2    | R Stick X   | z           |
+ * | 3    | R Stick Y   | rx          |
+ * | 4    | L Trigger   | ry          |
+ * | 5    | R Trigger   | rz          |
+ * | 6    | Hat X       | hat         |
+ * | 7    | Hat Y       | hat         |
+ *
+ * On top of this, Steam seems to have a different interpretation of
+ * gamepad data than other gamepad testers (https://gpadtester.com/,
+ * jstest-gtk, etc.). Ignore Steam's gamepad tester. Remap the inputs in Steam.
+ *
+ * The Swadge can map the D-Pad to either L Stick, R Stick, or Hat.
+ * The Swadge can map the touchpad to either L Stick, R Stick, or more buttons.
+ * The Swadge can map the accelerometer to LR Triggers or nothing.
+ */
+
 //==============================================================================
 // Includes
 //==============================================================================
@@ -1067,7 +1111,7 @@ void gamepadGenericMainLoop(int64_t elapsedUs __attribute__((unused)))
             // barY += (ACCEL_BAR_HEIGHT + ACCEL_BAR_SEP);
 
             // Plot Y accel
-            barWidth = ((gamepad->gpState.ry + 128) * MAX_ACCEL_BAR_W) / 256;
+            int16_t barWidth = ((gamepad->gpState.ry + 128) * MAX_ACCEL_BAR_W) / 256;
             fillDisplayArea(TFT_WIDTH - barWidth, barY, TFT_WIDTH, barY + ACCEL_BAR_HEIGHT, c050);
             barY += (ACCEL_BAR_HEIGHT + ACCEL_BAR_SEP);
 
@@ -1703,7 +1747,7 @@ void gamepadGenericReportStateToHost(void)
             {
                 if (touched || getGamepadPcTouchStickRecenterSetting())
                 {
-                    gamepad->gpState.z = x;
+                    gamepad->gpState.z  = x;
                     gamepad->gpState.rx = y;
                 }
                 break;

--- a/main/modes/utilities/gamepad/gamepad.c
+++ b/main/modes/utilities/gamepad/gamepad.c
@@ -1053,8 +1053,8 @@ void gamepadGenericMainLoop(int64_t elapsedUs __attribute__((unused)))
             if (ESP_OK == accelIntegrate() && ESP_OK == accelGetOrientVec(&a_x, &a_y, &a_z))
             {
                 // Values are roughly -256 to 256, so divide, clamp, and save
-                gamepad->gpState.rx = -CLAMP((a_x) / 2, -128, 127);
-                gamepad->gpState.ry = CLAMP((a_y) / 2, -128, 127);
+                gamepad->gpState.ry = -CLAMP((a_x) / 2, -128, 127);
+                gamepad->gpState.rz = CLAMP((a_y) / 2, -128, 127);
                 // gamepad->gpState.rz = CLAMP((a_z) / 2, -128, 127); //Nothing to map this to!
             }
 
@@ -1062,9 +1062,9 @@ void gamepadGenericMainLoop(int64_t elapsedUs __attribute__((unused)))
             int16_t barY = (TFT_HEIGHT * 3) / 4;
 
             // Plot X accel
-            int16_t barWidth = ((gamepad->gpState.rx + 128) * MAX_ACCEL_BAR_W) / 256;
-            fillDisplayArea(TFT_WIDTH - barWidth, barY, TFT_WIDTH, barY + ACCEL_BAR_HEIGHT, c500);
-            barY += (ACCEL_BAR_HEIGHT + ACCEL_BAR_SEP);
+            // int16_t barWidth = ((gamepad->gpState.rx + 128) * MAX_ACCEL_BAR_W) / 256;
+            // fillDisplayArea(TFT_WIDTH - barWidth, barY, TFT_WIDTH, barY + ACCEL_BAR_HEIGHT, c500);
+            // barY += (ACCEL_BAR_HEIGHT + ACCEL_BAR_SEP);
 
             // Plot Y accel
             barWidth = ((gamepad->gpState.ry + 128) * MAX_ACCEL_BAR_W) / 256;
@@ -1456,25 +1456,25 @@ void gamepadGenericButtonCb(buttonEvt_t* evt)
         }
         case GAMEPAD_DPAD_R_STICK_SETTING:
         {
+            gamepad->gpState.z  = 0;
             gamepad->gpState.rx = 0;
-            gamepad->gpState.ry = 0;
             int32_t intensity   = getGamepadPcDpadStickIntensitySetting();
 
             if (evt->state & PB_UP)
             {
-                gamepad->gpState.ry = -intensity;
+                gamepad->gpState.rx = -intensity;
             }
             if (evt->state & PB_DOWN)
             {
-                gamepad->gpState.ry = intensity;
+                gamepad->gpState.rx = intensity;
             }
             if (evt->state & PB_RIGHT)
             {
-                gamepad->gpState.rx = intensity;
+                gamepad->gpState.z = intensity;
             }
             if (evt->state & PB_LEFT)
             {
-                gamepad->gpState.rx = -intensity;
+                gamepad->gpState.z = -intensity;
             }
             break;
         }
@@ -1703,8 +1703,8 @@ void gamepadGenericReportStateToHost(void)
             {
                 if (touched || getGamepadPcTouchStickRecenterSetting())
                 {
-                    gamepad->gpState.rx = x;
-                    gamepad->gpState.ry = y;
+                    gamepad->gpState.z = x;
+                    gamepad->gpState.rx = y;
                 }
                 break;
             }

--- a/main/modes/utilities/gamepad/gamepad.c
+++ b/main/modes/utilities/gamepad/gamepad.c
@@ -179,14 +179,6 @@ swadgeMode_t gamepadMode = {
 
 };
 
-// const hid_gamepad_button_bm_t touchMap[] = {
-//     GAMEPAD_BUTTON_C, GAMEPAD_BUTTON_X, GAMEPAD_BUTTON_C, GAMEPAD_BUTTON_10, GAMEPAD_BUTTON_4,
-// };
-
-// const hid_gamepad_button_bm_t touchMapNs[] = {
-//     GAMEPAD_NS_BUTTON_Y, GAMEPAD_NS_BUTTON_TL, GAMEPAD_NS_BUTTON_Z, GAMEPAD_NS_BUTTON_TR, GAMEPAD_NS_BUTTON_X,
-// };
-
 /// @brief  Switch Descriptor
 static const tusb_desc_device_t nsDescriptor = {
     .bLength            = 18U,

--- a/main/modes/utilities/gamepad/gamepad.c
+++ b/main/modes/utilities/gamepad/gamepad.c
@@ -80,6 +80,7 @@ typedef struct
     uint16_t previousButtons;
     uint8_t previousHat;
     uint8_t bmpSlot;
+    uint8_t previousHatsDrawn;
 
     uint8_t gamepadType;
     bool isPluggedIn;
@@ -617,9 +618,66 @@ void gamepadNsMainLoop(int64_t elapsedUs __attribute__((unused)))
             xc += ((getSin1024(deg) * DPAD_CLUSTER_RADIUS) / 1024);
             yc += ((-getCos1024(deg) * DPAD_CLUSTER_RADIUS) / 1024);
 
-            drawFunc = (gamepad->gpNsState.hat == (hatDirs[i] - 1)) ? &drawCircleFilled : &drawCircle;
+            bool isPressed = false;
+            switch (getGamepadNsDpadSetting())
+            {
+                case GAMEPAD_DPAD_NORMAL_SETTING:
+                {
+                    isPressed = (gamepad->gpNsState.hat == hatDirs[i]);
+                    break;
+                }
+                case GAMEPAD_DPAD_L_STICK_SETTING:
+                case GAMEPAD_DPAD_R_STICK_SETTING:
+                {
+                    switch (hatDirs[i])
+                    {
+                        case GAMEPAD_HAT_UP:
+                        {
+                            isPressed = (0 == gamepad->gpNsState.x) && (0 > gamepad->gpNsState.y);
+                            break;
+                        }
+                        case GAMEPAD_HAT_UP_RIGHT:
+                        {
+                            isPressed = (0 < gamepad->gpNsState.x) && (0 > gamepad->gpNsState.y);
+                            break;
+                        }
+                        case GAMEPAD_HAT_RIGHT:
+                        {
+                            isPressed = (0 < gamepad->gpNsState.x) && (0 == gamepad->gpNsState.y);
+                            break;
+                        }
+                        case GAMEPAD_HAT_DOWN_RIGHT:
+                        {
+                            isPressed = (0 < gamepad->gpNsState.x) && (0 < gamepad->gpNsState.y);
+                            break;
+                        }
+                        case GAMEPAD_HAT_DOWN:
+                        {
+                            isPressed = (0 == gamepad->gpNsState.x) && (0 < gamepad->gpNsState.y);
+                            break;
+                        }
+                        case GAMEPAD_HAT_DOWN_LEFT:
+                        {
+                            isPressed = (0 > gamepad->gpNsState.x) && (0 < gamepad->gpNsState.y);
+                            break;
+                        }
+                        case GAMEPAD_HAT_LEFT:
+                        {
+                            isPressed = (0 > gamepad->gpNsState.x) && (0 == gamepad->gpNsState.y);
+                            break;
+                        }
+                        case GAMEPAD_HAT_UP_LEFT:
+                        {
+                            isPressed = (0 > gamepad->gpNsState.x) && (0 > gamepad->gpNsState.y);
+                            break;
+                        }
+                    }
+                    break;
+                }
+            }
 
-            drawFunc(xc, yc, DPAD_BTN_RADIUS, c551 /*paletteHsvToHex(i * 32, 0xFF, 0xFF)*/);
+            drawFunc = isPressed ? &drawCircleFilled : &drawCircle;
+            drawFunc(xc, yc, DPAD_BTN_RADIUS, c551);
         }
 
         // Select button
@@ -857,11 +915,13 @@ void gamepadGenericMainLoop(int64_t elapsedUs __attribute__((unused)))
         void (*drawFunc)(int, int, int, paletteColor_t);
 
         // A list of all the hat directions, in order
-        static const uint8_t hatDirs[]
-            = {GAMEPAD_HAT_UP,   GAMEPAD_HAT_UP_RIGHT,  GAMEPAD_HAT_RIGHT, GAMEPAD_HAT_DOWN_RIGHT,
-               GAMEPAD_HAT_DOWN, GAMEPAD_HAT_DOWN_LEFT, GAMEPAD_HAT_LEFT,  GAMEPAD_HAT_UP_LEFT};
+        static const uint8_t hatDirs[] = {
+            GAMEPAD_HAT_UP,   GAMEPAD_HAT_UP_RIGHT,  GAMEPAD_HAT_RIGHT, GAMEPAD_HAT_DOWN_RIGHT,
+            GAMEPAD_HAT_DOWN, GAMEPAD_HAT_DOWN_LEFT, GAMEPAD_HAT_LEFT,  GAMEPAD_HAT_UP_LEFT,
+        };
 
         // For each hat direction
+        uint8_t hatsDrawn = 0;
         for (uint8_t i = 0; i < ARRAY_SIZE(hatDirs); i++)
         {
             // The degree around the cluster
@@ -873,20 +933,81 @@ void gamepadGenericMainLoop(int64_t elapsedUs __attribute__((unused)))
             xc += ((getSin1024(deg) * DPAD_CLUSTER_RADIUS) / 1024);
             yc += ((-getCos1024(deg) * DPAD_CLUSTER_RADIUS) / 1024);
 
-            drawFunc = (gamepad->gpState.hat == hatDirs[i]) ? &drawCircleFilled : &drawCircle;
+            bool isPressed = false;
+            switch (getGamepadPcDpadSetting())
+            {
+                case GAMEPAD_DPAD_NORMAL_SETTING:
+                {
+                    isPressed = (gamepad->gpState.hat == hatDirs[i]);
+                    break;
+                }
+                case GAMEPAD_DPAD_L_STICK_SETTING:
+                case GAMEPAD_DPAD_R_STICK_SETTING:
+                {
+                    switch (hatDirs[i])
+                    {
+                        case GAMEPAD_HAT_UP:
+                        {
+                            isPressed = (0 == gamepad->gpState.x) && (0 > gamepad->gpState.y);
+                            break;
+                        }
+                        case GAMEPAD_HAT_UP_RIGHT:
+                        {
+                            isPressed = (0 < gamepad->gpState.x) && (0 > gamepad->gpState.y);
+                            break;
+                        }
+                        case GAMEPAD_HAT_RIGHT:
+                        {
+                            isPressed = (0 < gamepad->gpState.x) && (0 == gamepad->gpState.y);
+                            break;
+                        }
+                        case GAMEPAD_HAT_DOWN_RIGHT:
+                        {
+                            isPressed = (0 < gamepad->gpState.x) && (0 < gamepad->gpState.y);
+                            break;
+                        }
+                        case GAMEPAD_HAT_DOWN:
+                        {
+                            isPressed = (0 == gamepad->gpState.x) && (0 < gamepad->gpState.y);
+                            break;
+                        }
+                        case GAMEPAD_HAT_DOWN_LEFT:
+                        {
+                            isPressed = (0 > gamepad->gpState.x) && (0 < gamepad->gpState.y);
+                            break;
+                        }
+                        case GAMEPAD_HAT_LEFT:
+                        {
+                            isPressed = (0 > gamepad->gpState.x) && (0 == gamepad->gpState.y);
+                            break;
+                        }
+                        case GAMEPAD_HAT_UP_LEFT:
+                        {
+                            isPressed = (0 > gamepad->gpState.x) && (0 > gamepad->gpState.y);
+                            break;
+                        }
+                    }
+                    break;
+                }
+            }
 
-            drawFunc(xc, yc, DPAD_BTN_RADIUS, c551 /*paletteHsvToHex(i * 32, 0xFF, 0xFF)*/);
+            if (isPressed)
+            {
+                hatsDrawn |= (1 << i);
+            }
+            drawFunc = isPressed ? &drawCircleFilled : &drawCircle;
+            drawFunc(xc, yc, DPAD_BTN_RADIUS, c551);
         }
 
         // Select button
-        drawFunc = (gamepad->gpState.buttons & GAMEPAD_BUTTON_TL2) ? &drawCircleFilled : &drawCircle;
+        drawFunc = (gamepad->gpState.buttons & GAMEPAD_BUTTON_SELECT) ? &drawCircleFilled : &drawCircle;
 
         int16_t x = (TFT_WIDTH / 2) - START_BTN_RADIUS - START_BTN_SEP;
         int16_t y = ((3 * TFT_WIDTH) / 4) - START_BTN_Y_OFF + Y_OFF;
         drawFunc(x, y, START_BTN_RADIUS, c333);
 
         // Start button
-        drawFunc = (gamepad->gpState.buttons & GAMEPAD_BUTTON_TR2) ? &drawCircleFilled : &drawCircle;
+        drawFunc = (gamepad->gpState.buttons & GAMEPAD_BUTTON_START) ? &drawCircleFilled : &drawCircle;
 
         x = (TFT_WIDTH / 2) + START_BTN_RADIUS + START_BTN_SEP;
         drawFunc(x, y, START_BTN_RADIUS, c333);
@@ -974,21 +1095,19 @@ void gamepadGenericMainLoop(int64_t elapsedUs __attribute__((unused)))
         uint8_t bitmap[EYE_LED_H][EYE_LED_W] = {0};
         uint8_t btnBrightness                = 0;
 
-        if ((gamepad->gpState.hat == gamepad->previousHat) && (gamepad->gpState.buttons == gamepad->previousButtons))
+        // Only draw when there's a change
+        if (hatsDrawn != gamepad->previousHatsDrawn || gamepad->gpState.buttons != gamepad->previousButtons)
         {
-            // Skip eye update if no change
-        }
-        else
-        {
-            bitmap[5][0]  = (gamepad->gpState.buttons & GAMEPAD_BUTTON_4) ? EYE_LED_BRIGHT : 0;
-            bitmap[5][5]  = (gamepad->gpState.buttons & GAMEPAD_BUTTON_TL) ? EYE_LED_BRIGHT : 0;
-            bitmap[5][6]  = (gamepad->gpState.buttons & GAMEPAD_BUTTON_TR) ? EYE_LED_BRIGHT : 0;
-            bitmap[5][11] = (gamepad->gpState.buttons & GAMEPAD_BUTTON_5) ? EYE_LED_BRIGHT : 0;
+            gamepad->previousHatsDrawn = hatsDrawn;
 
-            bitmap[0][0]  = (gamepad->gpState.buttons & GAMEPAD_BUTTON_10) ? EYE_LED_BRIGHT : 0;
-            bitmap[0][5]  = (gamepad->gpState.buttons & GAMEPAD_BUTTON_TL2) ? EYE_LED_BRIGHT : 0;
-            bitmap[0][6]  = (gamepad->gpState.buttons & GAMEPAD_BUTTON_TR2) ? EYE_LED_BRIGHT : 0;
-            bitmap[0][11] = (gamepad->gpState.buttons & GAMEPAD_BUTTON_11) ? EYE_LED_BRIGHT : 0;
+            bitmap[5][5] = (gamepad->gpState.buttons & GAMEPAD_BUTTON_TL) ? EYE_LED_BRIGHT : 0;
+            bitmap[5][6] = (gamepad->gpState.buttons & GAMEPAD_BUTTON_TR) ? EYE_LED_BRIGHT : 0;
+
+            bitmap[0][5] = (gamepad->gpState.buttons & GAMEPAD_BUTTON_TL2) ? EYE_LED_BRIGHT : 0;
+            bitmap[0][6] = (gamepad->gpState.buttons & GAMEPAD_BUTTON_TR2) ? EYE_LED_BRIGHT : 0;
+
+            bitmap[0][0]  = (gamepad->gpState.buttons & GAMEPAD_BUTTON_SELECT) ? EYE_LED_BRIGHT : 0;
+            bitmap[0][11] = (gamepad->gpState.buttons & GAMEPAD_BUTTON_START) ? EYE_LED_BRIGHT : 0;
 
             btnBrightness = (gamepad->gpState.buttons & GAMEPAD_BUTTON_X) ? EYE_LED_BRIGHT : 0;
             bitmap[5][8]  = btnBrightness;
@@ -1008,90 +1127,49 @@ void gamepadGenericMainLoop(int64_t elapsedUs __attribute__((unused)))
             bitmap[0][8]  = btnBrightness;
             bitmap[0][9]  = btnBrightness;
 
-            btnBrightness = (gamepad->gpState.buttons & GAMEPAD_BUTTON_C) ? EYE_LED_BRIGHT : 0;
+            btnBrightness = (gamepad->gpState.buttons & GAMEPAD_BUTTON_Y) ? EYE_LED_BRIGHT : 0;
             bitmap[3][6]  = btnBrightness;
             bitmap[3][7]  = btnBrightness;
             bitmap[2][6]  = btnBrightness;
             bitmap[2][7]  = btnBrightness;
 
-            btnBrightness = (gamepad->gpState.buttons & GAMEPAD_BUTTON_12) ? EYE_LED_BRIGHT : 0;
-            bitmap[5][2]  = btnBrightness;
-            bitmap[5][3]  = btnBrightness;
-            bitmap[4][2]  = btnBrightness;
-            bitmap[4][3]  = btnBrightness;
-
-            btnBrightness = (gamepad->gpState.buttons & GAMEPAD_BUTTON_15) ? EYE_LED_BRIGHT : 0;
-            bitmap[3][4]  = btnBrightness;
-            bitmap[3][5]  = btnBrightness;
-            bitmap[2][4]  = btnBrightness;
-            bitmap[2][5]  = btnBrightness;
-
-            btnBrightness = (gamepad->gpState.buttons & GAMEPAD_BUTTON_13) ? EYE_LED_BRIGHT : 0;
-            bitmap[1][2]  = btnBrightness;
-            bitmap[1][3]  = btnBrightness;
-            bitmap[0][2]  = btnBrightness;
-            bitmap[0][3]  = btnBrightness;
-
-            btnBrightness = (gamepad->gpState.buttons & GAMEPAD_BUTTON_14) ? EYE_LED_BRIGHT : 0;
-            bitmap[3][0]  = btnBrightness;
-            bitmap[3][1]  = btnBrightness;
-            bitmap[2][0]  = btnBrightness;
-            bitmap[2][1]  = btnBrightness;
-
-            switch (gamepad->gpState.hat)
+            if (hatsDrawn
+                & ((1 << (GAMEPAD_HAT_UP - 1)) | (1 << (GAMEPAD_HAT_UP_LEFT - 1)) | (1 << (GAMEPAD_HAT_UP_RIGHT - 1))))
             {
-                case GAMEPAD_HAT_UP:
-                case GAMEPAD_HAT_UP_LEFT:
-                case GAMEPAD_HAT_UP_RIGHT:
-                    bitmap[5][2] = EYE_LED_BRIGHT;
-                    bitmap[5][3] = EYE_LED_BRIGHT;
-                    bitmap[4][2] = EYE_LED_BRIGHT;
-                    bitmap[4][3] = EYE_LED_BRIGHT;
-                    // fallthrough
-                default:
-                    break;
+                bitmap[5][2] = EYE_LED_BRIGHT;
+                bitmap[5][3] = EYE_LED_BRIGHT;
+                bitmap[4][2] = EYE_LED_BRIGHT;
+                bitmap[4][3] = EYE_LED_BRIGHT;
             }
 
-            switch (gamepad->gpState.hat)
+            if (hatsDrawn
+                & ((1 << (GAMEPAD_HAT_RIGHT - 1)) | (1 << (GAMEPAD_HAT_UP_RIGHT - 1))
+                   | (1 << (GAMEPAD_HAT_DOWN_RIGHT - 1))))
             {
-                case GAMEPAD_HAT_RIGHT:
-                case GAMEPAD_HAT_UP_RIGHT:
-                case GAMEPAD_HAT_DOWN_RIGHT:
-                    bitmap[3][4] = EYE_LED_BRIGHT;
-                    bitmap[3][5] = EYE_LED_BRIGHT;
-                    bitmap[2][4] = EYE_LED_BRIGHT;
-                    bitmap[2][5] = EYE_LED_BRIGHT;
-                    // fallthrough
-                default:
-                    break;
+                bitmap[3][4] = EYE_LED_BRIGHT;
+                bitmap[3][5] = EYE_LED_BRIGHT;
+                bitmap[2][4] = EYE_LED_BRIGHT;
+                bitmap[2][5] = EYE_LED_BRIGHT;
             }
 
-            switch (gamepad->gpState.hat)
+            if (hatsDrawn
+                & ((1 << (GAMEPAD_HAT_DOWN - 1)) | (1 << (GAMEPAD_HAT_DOWN_RIGHT - 1))
+                   | (1 << (GAMEPAD_HAT_DOWN_LEFT - 1))))
             {
-                case GAMEPAD_HAT_DOWN:
-                case GAMEPAD_HAT_DOWN_RIGHT:
-                case GAMEPAD_HAT_DOWN_LEFT:
-                    bitmap[1][2] = EYE_LED_BRIGHT;
-                    bitmap[1][3] = EYE_LED_BRIGHT;
-                    bitmap[0][2] = EYE_LED_BRIGHT;
-                    bitmap[0][3] = EYE_LED_BRIGHT;
-                    // fallthrough
-                default:
-                    break;
+                bitmap[1][2] = EYE_LED_BRIGHT;
+                bitmap[1][3] = EYE_LED_BRIGHT;
+                bitmap[0][2] = EYE_LED_BRIGHT;
+                bitmap[0][3] = EYE_LED_BRIGHT;
             }
 
-            switch (gamepad->gpState.hat)
+            if (hatsDrawn
+                & ((1 << (GAMEPAD_HAT_LEFT - 1)) | (1 << (GAMEPAD_HAT_UP_LEFT - 1))
+                   | (1 << (GAMEPAD_HAT_DOWN_LEFT - 1))))
             {
-                case GAMEPAD_HAT_LEFT:
-                case GAMEPAD_HAT_UP_LEFT:
-                case GAMEPAD_HAT_DOWN_LEFT:
-                    bitmap[3][0] = EYE_LED_BRIGHT;
-                    bitmap[3][1] = EYE_LED_BRIGHT;
-                    bitmap[2][0] = EYE_LED_BRIGHT;
-                    bitmap[2][1] = EYE_LED_BRIGHT;
-                    // fallthrough
-                default:
-                    break;
+                bitmap[3][0] = EYE_LED_BRIGHT;
+                bitmap[3][1] = EYE_LED_BRIGHT;
+                bitmap[2][0] = EYE_LED_BRIGHT;
+                bitmap[2][1] = EYE_LED_BRIGHT;
             }
 
             // Write and select the bitmap to an unused slot
@@ -1312,25 +1390,11 @@ void gamepadGenericButtonCb(buttonEvt_t* evt)
     }
     if (evt->state & PB_START)
     {
-        if (evt->state & PB_DOWN)
-        {
-            gamepad->gpState.buttons |= GAMEPAD_BUTTON_11;
-        }
-        else
-        {
-            gamepad->gpState.buttons |= GAMEPAD_BUTTON_TR2;
-        }
+        gamepad->gpState.buttons |= GAMEPAD_BUTTON_START;
     }
     if (evt->state & PB_SELECT)
     {
-        if (evt->state & PB_DOWN)
-        {
-            gamepad->gpState.buttons |= GAMEPAD_BUTTON_10;
-        }
-        else
-        {
-            gamepad->gpState.buttons |= GAMEPAD_BUTTON_TL2;
-        }
+        gamepad->gpState.buttons |= GAMEPAD_BUTTON_SELECT;
     }
 
     // Figure out which way the D-Pad is pointing
@@ -1580,8 +1644,8 @@ void gamepadGenericReportStateToHost(void)
         {
             case GAMEPAD_TOUCH_MORE_BUTTONS_SETTING:
             {
-                gamepad->gpState.buttons &= ~(GAMEPAD_BUTTON_X | GAMEPAD_BUTTON_C | GAMEPAD_BUTTON_4 | GAMEPAD_BUTTON_5
-                                              | GAMEPAD_BUTTON_TL | GAMEPAD_BUTTON_TR);
+                gamepad->gpState.buttons &= ~(GAMEPAD_BUTTON_X | GAMEPAD_BUTTON_Y | GAMEPAD_BUTTON_TL
+                                              | GAMEPAD_BUTTON_TR | GAMEPAD_BUTTON_TL2 | GAMEPAD_BUTTON_TR2);
                 if (!touched)
                 {
                     break;
@@ -1597,44 +1661,44 @@ void gamepadGenericReportStateToHost(void)
                     }
                     case TB_RIGHT:
                     {
-                        gamepad->gpState.buttons |= GAMEPAD_BUTTON_X;
+                        gamepad->gpState.buttons |= GAMEPAD_BUTTON_Y;
                         break;
                     }
                     case TB_UP_RIGHT:
                     {
-                        gamepad->gpState.buttons |= GAMEPAD_BUTTON_5;
+                        gamepad->gpState.buttons |= GAMEPAD_BUTTON_TR;
                         break;
                     }
                     case TB_UP:
                     {
-                        gamepad->gpState.buttons |= GAMEPAD_BUTTON_5;
-                        gamepad->gpState.buttons |= GAMEPAD_BUTTON_4;
+                        gamepad->gpState.buttons |= GAMEPAD_BUTTON_TR;
+                        gamepad->gpState.buttons |= GAMEPAD_BUTTON_TL;
                         break;
                     }
                     case TB_UP_LEFT:
                     {
-                        gamepad->gpState.buttons |= GAMEPAD_BUTTON_4;
+                        gamepad->gpState.buttons |= GAMEPAD_BUTTON_TL;
                         break;
                     }
                     case TB_LEFT:
                     {
-                        gamepad->gpState.buttons |= GAMEPAD_BUTTON_C;
+                        gamepad->gpState.buttons |= GAMEPAD_BUTTON_X;
                         break;
                     }
                     case TB_DOWN_LEFT:
                     {
-                        gamepad->gpState.buttons |= GAMEPAD_BUTTON_TL;
+                        gamepad->gpState.buttons |= GAMEPAD_BUTTON_TL2;
                         break;
                     }
                     case TB_DOWN:
                     {
-                        gamepad->gpState.buttons |= GAMEPAD_BUTTON_TL;
-                        gamepad->gpState.buttons |= GAMEPAD_BUTTON_TR;
+                        gamepad->gpState.buttons |= GAMEPAD_BUTTON_TL2;
+                        gamepad->gpState.buttons |= GAMEPAD_BUTTON_TR2;
                         break;
                     }
                     case TB_DOWN_RIGHT:
                     {
-                        gamepad->gpState.buttons |= GAMEPAD_BUTTON_TR;
+                        gamepad->gpState.buttons |= GAMEPAD_BUTTON_TR2;
                         break;
                     }
                 }

--- a/main/modes/utilities/gamepad/gamepad.c
+++ b/main/modes/utilities/gamepad/gamepad.c
@@ -44,6 +44,8 @@
 #define TOUCHPAD_Y_OFF 8
 #define TOUCHPAD_X_OFF 10
 
+#define GP_NS_CENTERED -128
+
 //==============================================================================
 // Enums
 //==============================================================================
@@ -477,10 +479,10 @@ void gamepadStart(gamepadType_t type)
         initTusb(&pc_tusb_cfg, hid_report_descriptor);
     }
 
-    gamepad->gpNsState.x  = 128;
-    gamepad->gpNsState.y  = 128;
-    gamepad->gpNsState.rx = 128;
-    gamepad->gpNsState.ry = 128;
+    gamepad->gpNsState.x  = GP_NS_CENTERED;
+    gamepad->gpNsState.y  = GP_NS_CENTERED;
+    gamepad->gpNsState.rx = GP_NS_CENTERED;
+    gamepad->gpNsState.ry = GP_NS_CENTERED;
 
     led_t leds[CONFIG_NUM_LEDS];
     memset(leds, 0, sizeof(leds));
@@ -602,8 +604,8 @@ void gamepadNsMainLoop(int64_t elapsedUs __attribute__((unused)))
 
         // A list of all the hat directions, in order
         static const uint8_t hatDirs[] = {
-            GAMEPAD_HAT_UP,   GAMEPAD_HAT_UP_RIGHT,  GAMEPAD_HAT_RIGHT, GAMEPAD_HAT_DOWN_RIGHT,
-            GAMEPAD_HAT_DOWN, GAMEPAD_HAT_DOWN_LEFT, GAMEPAD_HAT_LEFT,  GAMEPAD_HAT_UP_LEFT,
+            GAMEPAD_NS_HAT_UP,   GAMEPAD_NS_HAT_UP_RIGHT,  GAMEPAD_NS_HAT_RIGHT, GAMEPAD_NS_HAT_DOWN_RIGHT,
+            GAMEPAD_NS_HAT_DOWN, GAMEPAD_NS_HAT_DOWN_LEFT, GAMEPAD_NS_HAT_LEFT,  GAMEPAD_NS_HAT_UP_LEFT,
         };
 
         // For each hat direction
@@ -632,44 +634,52 @@ void gamepadNsMainLoop(int64_t elapsedUs __attribute__((unused)))
                 {
                     switch (hatDirs[i])
                     {
-                        case GAMEPAD_HAT_UP:
+                        case GAMEPAD_NS_HAT_UP:
                         {
-                            isPressed = (128 == gamepad->gpNsState.x) && (128 > gamepad->gpNsState.y);
+                            isPressed
+                                = (GP_NS_CENTERED == gamepad->gpNsState.x) && (GP_NS_CENTERED > gamepad->gpNsState.y);
                             break;
                         }
-                        case GAMEPAD_HAT_UP_RIGHT:
+                        case GAMEPAD_NS_HAT_UP_RIGHT:
                         {
-                            isPressed = (128 < gamepad->gpNsState.x) && (128 > gamepad->gpNsState.y);
+                            isPressed
+                                = (GP_NS_CENTERED < gamepad->gpNsState.x) && (GP_NS_CENTERED > gamepad->gpNsState.y);
                             break;
                         }
-                        case GAMEPAD_HAT_RIGHT:
+                        case GAMEPAD_NS_HAT_RIGHT:
                         {
-                            isPressed = (128 < gamepad->gpNsState.x) && (128 == gamepad->gpNsState.y);
+                            isPressed
+                                = (GP_NS_CENTERED < gamepad->gpNsState.x) && (GP_NS_CENTERED == gamepad->gpNsState.y);
                             break;
                         }
-                        case GAMEPAD_HAT_DOWN_RIGHT:
+                        case GAMEPAD_NS_HAT_DOWN_RIGHT:
                         {
-                            isPressed = (128 < gamepad->gpNsState.x) && (128 < gamepad->gpNsState.y);
+                            isPressed
+                                = (GP_NS_CENTERED < gamepad->gpNsState.x) && (GP_NS_CENTERED < gamepad->gpNsState.y);
                             break;
                         }
-                        case GAMEPAD_HAT_DOWN:
+                        case GAMEPAD_NS_HAT_DOWN:
                         {
-                            isPressed = (128 == gamepad->gpNsState.x) && (128 < gamepad->gpNsState.y);
+                            isPressed
+                                = (GP_NS_CENTERED == gamepad->gpNsState.x) && (GP_NS_CENTERED < gamepad->gpNsState.y);
                             break;
                         }
-                        case GAMEPAD_HAT_DOWN_LEFT:
+                        case GAMEPAD_NS_HAT_DOWN_LEFT:
                         {
-                            isPressed = (128 > gamepad->gpNsState.x) && (128 < gamepad->gpNsState.y);
+                            isPressed
+                                = (GP_NS_CENTERED > gamepad->gpNsState.x) && (GP_NS_CENTERED < gamepad->gpNsState.y);
                             break;
                         }
-                        case GAMEPAD_HAT_LEFT:
+                        case GAMEPAD_NS_HAT_LEFT:
                         {
-                            isPressed = (128 > gamepad->gpNsState.x) && (128 == gamepad->gpNsState.y);
+                            isPressed
+                                = (GP_NS_CENTERED > gamepad->gpNsState.x) && (GP_NS_CENTERED == gamepad->gpNsState.y);
                             break;
                         }
-                        case GAMEPAD_HAT_UP_LEFT:
+                        case GAMEPAD_NS_HAT_UP_LEFT:
                         {
-                            isPressed = (128 > gamepad->gpNsState.x) && (128 > gamepad->gpNsState.y);
+                            isPressed
+                                = (GP_NS_CENTERED > gamepad->gpNsState.x) && (GP_NS_CENTERED > gamepad->gpNsState.y);
                             break;
                         }
                     }
@@ -799,8 +809,7 @@ void gamepadNsMainLoop(int64_t elapsedUs __attribute__((unused)))
             bitmap[2][7]  = btnBrightness;
 
             if (hatsDrawn
-                & ((1 << (GAMEPAD_NS_HAT_UP - 1)) | (1 << (GAMEPAD_NS_HAT_UP_LEFT - 1))
-                   | (1 << (GAMEPAD_NS_HAT_UP_RIGHT - 1))))
+                & ((1 << (GAMEPAD_NS_HAT_UP)) | (1 << (GAMEPAD_NS_HAT_UP_LEFT)) | (1 << (GAMEPAD_NS_HAT_UP_RIGHT))))
             {
                 bitmap[5][2] = EYE_LED_BRIGHT;
                 bitmap[5][3] = EYE_LED_BRIGHT;
@@ -809,8 +818,8 @@ void gamepadNsMainLoop(int64_t elapsedUs __attribute__((unused)))
             }
 
             if (hatsDrawn
-                & ((1 << (GAMEPAD_NS_HAT_RIGHT - 1)) | (1 << (GAMEPAD_NS_HAT_UP_RIGHT - 1))
-                   | (1 << (GAMEPAD_NS_HAT_DOWN_RIGHT - 1))))
+                & ((1 << (GAMEPAD_NS_HAT_RIGHT)) | (1 << (GAMEPAD_NS_HAT_UP_RIGHT))
+                   | (1 << (GAMEPAD_NS_HAT_DOWN_RIGHT))))
             {
                 bitmap[3][4] = EYE_LED_BRIGHT;
                 bitmap[3][5] = EYE_LED_BRIGHT;
@@ -819,8 +828,8 @@ void gamepadNsMainLoop(int64_t elapsedUs __attribute__((unused)))
             }
 
             if (hatsDrawn
-                & ((1 << (GAMEPAD_NS_HAT_DOWN - 1)) | (1 << (GAMEPAD_NS_HAT_DOWN_RIGHT - 1))
-                   | (1 << (GAMEPAD_NS_HAT_DOWN_LEFT - 1))))
+                & ((1 << (GAMEPAD_NS_HAT_DOWN)) | (1 << (GAMEPAD_NS_HAT_DOWN_RIGHT))
+                   | (1 << (GAMEPAD_NS_HAT_DOWN_LEFT))))
             {
                 bitmap[1][2] = EYE_LED_BRIGHT;
                 bitmap[1][3] = EYE_LED_BRIGHT;
@@ -829,8 +838,7 @@ void gamepadNsMainLoop(int64_t elapsedUs __attribute__((unused)))
             }
 
             if (hatsDrawn
-                & ((1 << (GAMEPAD_NS_HAT_LEFT - 1)) | (1 << (GAMEPAD_NS_HAT_UP_LEFT - 1))
-                   | (1 << (GAMEPAD_NS_HAT_DOWN_LEFT - 1))))
+                & ((1 << (GAMEPAD_NS_HAT_LEFT)) | (1 << (GAMEPAD_NS_HAT_UP_LEFT)) | (1 << (GAMEPAD_NS_HAT_DOWN_LEFT))))
             {
                 bitmap[3][0] = EYE_LED_BRIGHT;
                 bitmap[3][1] = EYE_LED_BRIGHT;
@@ -1288,49 +1296,49 @@ void gamepadNsButtonCb(buttonEvt_t* evt)
         }
         case GAMEPAD_DPAD_L_STICK_SETTING:
         {
-            gamepad->gpNsState.x = 128;
-            gamepad->gpNsState.y = 128;
+            gamepad->gpNsState.x = GP_NS_CENTERED;
+            gamepad->gpNsState.y = GP_NS_CENTERED;
             int32_t intensity    = getGamepadNsDpadStickIntensitySetting();
 
             if (evt->state & PB_UP)
             {
-                gamepad->gpNsState.y = 128 - intensity;
+                gamepad->gpNsState.y = GP_NS_CENTERED - intensity;
             }
             if (evt->state & PB_DOWN)
             {
-                gamepad->gpNsState.y = 128 + intensity;
+                gamepad->gpNsState.y = GP_NS_CENTERED + intensity;
             }
             if (evt->state & PB_RIGHT)
             {
-                gamepad->gpNsState.x = 128 + intensity;
+                gamepad->gpNsState.x = GP_NS_CENTERED + intensity;
             }
             if (evt->state & PB_LEFT)
             {
-                gamepad->gpNsState.x = 128 - intensity;
+                gamepad->gpNsState.x = GP_NS_CENTERED - intensity;
             }
             break;
         }
         case GAMEPAD_DPAD_R_STICK_SETTING:
         {
-            gamepad->gpNsState.rx = 128;
-            gamepad->gpNsState.ry = 128;
+            gamepad->gpNsState.rx = GP_NS_CENTERED;
+            gamepad->gpNsState.ry = GP_NS_CENTERED;
             int32_t intensity     = getGamepadNsDpadStickIntensitySetting();
 
             if (evt->state & PB_UP)
             {
-                gamepad->gpNsState.ry = 128 - intensity;
+                gamepad->gpNsState.ry = GP_NS_CENTERED - intensity;
             }
             if (evt->state & PB_DOWN)
             {
-                gamepad->gpNsState.ry = 128 + intensity;
+                gamepad->gpNsState.ry = GP_NS_CENTERED + intensity;
             }
             if (evt->state & PB_RIGHT)
             {
-                gamepad->gpNsState.rx = 128 + intensity;
+                gamepad->gpNsState.rx = GP_NS_CENTERED + intensity;
             }
             if (evt->state & PB_LEFT)
             {
-                gamepad->gpNsState.rx = 128 - intensity;
+                gamepad->gpNsState.rx = GP_NS_CENTERED - intensity;
             }
             break;
         }
@@ -1506,8 +1514,8 @@ void gamepadNsReportStateToHost(void)
         }
         else
         {
-            x = 128;
-            y = 128;
+            x = GP_NS_CENTERED;
+            y = GP_NS_CENTERED;
         }
 
         switch (touchSetting)

--- a/main/modes/utilities/gamepad/gamepad.c
+++ b/main/modes/utilities/gamepad/gamepad.c
@@ -857,10 +857,9 @@ void gamepadGenericMainLoop(int64_t elapsedUs __attribute__((unused)))
         void (*drawFunc)(int, int, int, paletteColor_t);
 
         // A list of all the hat directions, in order
-        static const uint8_t hatDirs[] = {
-            GAMEPAD_HAT_UP,   GAMEPAD_HAT_UP_RIGHT,  GAMEPAD_HAT_RIGHT, GAMEPAD_HAT_DOWN_RIGHT,
-            GAMEPAD_HAT_DOWN, GAMEPAD_HAT_DOWN_LEFT, GAMEPAD_HAT_LEFT,  GAMEPAD_HAT_UP_LEFT,
-        };
+        static const uint8_t hatDirs[]
+            = {GAMEPAD_HAT_UP,   GAMEPAD_HAT_UP_RIGHT,  GAMEPAD_HAT_RIGHT, GAMEPAD_HAT_DOWN_RIGHT,
+               GAMEPAD_HAT_DOWN, GAMEPAD_HAT_DOWN_LEFT, GAMEPAD_HAT_LEFT,  GAMEPAD_HAT_UP_LEFT};
 
         // For each hat direction
         for (uint8_t i = 0; i < ARRAY_SIZE(hatDirs); i++)
@@ -947,9 +946,9 @@ void gamepadGenericMainLoop(int64_t elapsedUs __attribute__((unused)))
             if (ESP_OK == accelIntegrate() && ESP_OK == accelGetOrientVec(&a_x, &a_y, &a_z))
             {
                 // Values are roughly -256 to 256, so divide, clamp, and save
-                gamepad->gpState.z = -CLAMP((a_x) / 2, -128, 127);
-                gamepad->gpState.rx = CLAMP((a_y) / 2, -128, 127);
-                //gamepad->gpState.rz = CLAMP((a_z) / 2, -128, 127); //Nothing to map this to!
+                gamepad->gpState.rx = -CLAMP((a_x) / 2, -128, 127);
+                gamepad->gpState.ry = CLAMP((a_y) / 2, -128, 127);
+                // gamepad->gpState.rz = CLAMP((a_z) / 2, -128, 127); //Nothing to map this to!
             }
 
             // Set up drawing accel bars
@@ -1016,30 +1015,30 @@ void gamepadGenericMainLoop(int64_t elapsedUs __attribute__((unused)))
             bitmap[2][7]  = btnBrightness;
 
             btnBrightness = (gamepad->gpState.buttons & GAMEPAD_BUTTON_12) ? EYE_LED_BRIGHT : 0;
-            bitmap[5][2] = btnBrightness;
-            bitmap[5][3] = btnBrightness;
-            bitmap[4][2] = btnBrightness;
-            bitmap[4][3] = btnBrightness;
+            bitmap[5][2]  = btnBrightness;
+            bitmap[5][3]  = btnBrightness;
+            bitmap[4][2]  = btnBrightness;
+            bitmap[4][3]  = btnBrightness;
 
             btnBrightness = (gamepad->gpState.buttons & GAMEPAD_BUTTON_15) ? EYE_LED_BRIGHT : 0;
-            bitmap[3][4] = btnBrightness;
-            bitmap[3][5] = btnBrightness;
-            bitmap[2][4] = btnBrightness;
-            bitmap[2][5] = btnBrightness;
+            bitmap[3][4]  = btnBrightness;
+            bitmap[3][5]  = btnBrightness;
+            bitmap[2][4]  = btnBrightness;
+            bitmap[2][5]  = btnBrightness;
 
             btnBrightness = (gamepad->gpState.buttons & GAMEPAD_BUTTON_13) ? EYE_LED_BRIGHT : 0;
-            bitmap[1][2] = btnBrightness;
-            bitmap[1][3] = btnBrightness;
-            bitmap[0][2] = btnBrightness;
-            bitmap[0][3] = btnBrightness;
+            bitmap[1][2]  = btnBrightness;
+            bitmap[1][3]  = btnBrightness;
+            bitmap[0][2]  = btnBrightness;
+            bitmap[0][3]  = btnBrightness;
 
             btnBrightness = (gamepad->gpState.buttons & GAMEPAD_BUTTON_14) ? EYE_LED_BRIGHT : 0;
-            bitmap[3][0] = btnBrightness;
-            bitmap[3][1] = btnBrightness;
-            bitmap[2][0] = btnBrightness;
-            bitmap[2][1] = btnBrightness;
+            bitmap[3][0]  = btnBrightness;
+            bitmap[3][1]  = btnBrightness;
+            bitmap[2][0]  = btnBrightness;
+            bitmap[2][1]  = btnBrightness;
 
-            /*switch (gamepad->gpState.hat)
+            switch (gamepad->gpState.hat)
             {
                 case GAMEPAD_HAT_UP:
                 case GAMEPAD_HAT_UP_LEFT:
@@ -1093,7 +1092,7 @@ void gamepadGenericMainLoop(int64_t elapsedUs __attribute__((unused)))
                     // fallthrough
                 default:
                     break;
-            }*/
+            }
 
             // Write and select the bitmap to an unused slot
             ch32v003WriteBitmap(gamepad->bmpSlot, bitmap);
@@ -1299,8 +1298,10 @@ void gamepadGenericButtonCb(buttonEvt_t* evt)
     // Build a list of all independent buttons held down
     gamepad->gpState.buttons &= ~(GAMEPAD_BUTTON_B | GAMEPAD_BUTTON_A | GAMEPAD_BUTTON_TR2 | GAMEPAD_BUTTON_TL2
                                   | GAMEPAD_BUTTON_11 | GAMEPAD_BUTTON_10 | GAMEPAD_BUTTON_X | GAMEPAD_BUTTON_C
-                                  | GAMEPAD_BUTTON_4 | GAMEPAD_BUTTON_5 | GAMEPAD_BUTTON_TL | GAMEPAD_BUTTON_TR | GAMEPAD_BUTTON_12 | GAMEPAD_BUTTON_13 | GAMEPAD_BUTTON_14 | GAMEPAD_BUTTON_15);
+                                  | GAMEPAD_BUTTON_4 | GAMEPAD_BUTTON_5 | GAMEPAD_BUTTON_TL | GAMEPAD_BUTTON_TR
+                                  | GAMEPAD_BUTTON_12 | GAMEPAD_BUTTON_13 | GAMEPAD_BUTTON_14 | GAMEPAD_BUTTON_15);
 
+    // Map to XBOX style, not labels
     if (evt->state & PB_A)
     {
         gamepad->gpState.buttons |= GAMEPAD_BUTTON_B;
@@ -1341,49 +1342,41 @@ void gamepadGenericButtonCb(buttonEvt_t* evt)
             gamepad->gpState.hat = GAMEPAD_HAT_CENTERED;
             if (evt->state & PB_UP)
             {
-                /*if (evt->state & PB_RIGHT)
+                if (evt->state & PB_RIGHT)
                 {
                     gamepad->gpState.hat = GAMEPAD_HAT_UP_RIGHT;
-                    gamepad->gpState.buttons |= GAMEPAD_BUTTON_15;
                 }
                 else if (evt->state & PB_LEFT)
                 {
                     gamepad->gpState.hat = GAMEPAD_HAT_UP_LEFT;
-                    gamepad->gpState.buttons |= GAMEPAD_BUTTON_14;
                 }
                 else
-                {*/
+                {
                     gamepad->gpState.hat = GAMEPAD_HAT_UP;
-                    gamepad->gpState.buttons |= GAMEPAD_BUTTON_12;
-                //}
+                }
             }
-            /*else*/ if (evt->state & PB_DOWN)
+            else if (evt->state & PB_DOWN)
             {
-                /*if (evt->state & PB_RIGHT)
+                if (evt->state & PB_RIGHT)
                 {
                     gamepad->gpState.hat = GAMEPAD_HAT_DOWN_RIGHT;
-                    gamepad->gpState.buttons |= GAMEPAD_BUTTON_15;
                 }
                 else if (evt->state & PB_LEFT)
                 {
                     gamepad->gpState.hat = GAMEPAD_HAT_DOWN_LEFT;
-                    gamepad->gpState.buttons |= GAMEPAD_BUTTON_14;
                 }
                 else
-                {*/
+                {
                     gamepad->gpState.hat = GAMEPAD_HAT_DOWN;
-                    gamepad->gpState.buttons |= GAMEPAD_BUTTON_13;
-                //}
+                }
             }
-            if (evt->state & PB_RIGHT)
+            else if (evt->state & PB_RIGHT)
             {
                 gamepad->gpState.hat = GAMEPAD_HAT_RIGHT;
-                gamepad->gpState.buttons |= GAMEPAD_BUTTON_15;
             }
-            if (evt->state & PB_LEFT)
+            else if (evt->state & PB_LEFT)
             {
                 gamepad->gpState.hat = GAMEPAD_HAT_LEFT;
-                gamepad->gpState.buttons |= GAMEPAD_BUTTON_14;
             }
             break;
         }
@@ -1413,25 +1406,25 @@ void gamepadGenericButtonCb(buttonEvt_t* evt)
         }
         case GAMEPAD_DPAD_R_STICK_SETTING:
         {
-            gamepad->gpState.z = 0;
             gamepad->gpState.rx = 0;
+            gamepad->gpState.ry = 0;
             int32_t intensity   = getGamepadPcDpadStickIntensitySetting();
 
             if (evt->state & PB_UP)
             {
-                gamepad->gpState.rx = -intensity;
+                gamepad->gpState.ry = -intensity;
             }
             if (evt->state & PB_DOWN)
             {
-                gamepad->gpState.rx = intensity;
+                gamepad->gpState.ry = intensity;
             }
             if (evt->state & PB_RIGHT)
             {
-                gamepad->gpState.z = intensity;
+                gamepad->gpState.rx = intensity;
             }
             if (evt->state & PB_LEFT)
             {
-                gamepad->gpState.z = -intensity;
+                gamepad->gpState.rx = -intensity;
             }
             break;
         }
@@ -1454,19 +1447,17 @@ void gamepadNsReportStateToHost(void)
         touched                     = getTouchJoystick(&phi, &r, &intensity);
         gamepadTouch_t touchSetting = getGamepadNsTouchSetting();
 
-        int32_t x, y, z;
+        int32_t x, y;
         if (touched)
         {
             getTouchCartesian(phi, r, &x, &y);
             x = (255 * x) / 1024;
             y = (-255 * y) / 1024;
-            z = 0;
         }
         else
         {
             x = 128;
             y = 128;
-            z = 0;
         }
 
         switch (touchSetting)
@@ -1539,7 +1530,6 @@ void gamepadNsReportStateToHost(void)
                 {
                     gamepad->gpNsState.x = x;
                     gamepad->gpNsState.y = y;
-                    //gamepad->gpNsState.z = z;
                 }
                 break;
             }
@@ -1547,9 +1537,8 @@ void gamepadNsReportStateToHost(void)
             {
                 if (touched || getGamepadPcTouchStickRecenterSetting())
                 {
-                    gamepad->gpNsState.z = x;
-                    gamepad->gpNsState.rx = y;
-                    //gamepad->gpNsState.rz = z;
+                    gamepad->gpNsState.rx = x;
+                    gamepad->gpNsState.ry = y;
                 }
                 break;
             }
@@ -1573,20 +1562,17 @@ void gamepadGenericReportStateToHost(void)
         int32_t phi, r, intensity;
         touched = getTouchJoystick(&phi, &r, &intensity);
 
-        int32_t x, y, z;
+        int32_t x, y;
         if (touched)
         {
             getTouchCartesian(phi, r, &x, &y);
             x = (255 * x) / 1024 - 128;
             y = (-255 * y) / 1024 - 128;
-            // gamepad->gpState.z = (127 * (phi - 180)) / 360;
-            z = 0;
         }
         else
         {
             x = 0;
             y = 0;
-            z = 0;
         }
 
         gamepadTouch_t touchSetting = getGamepadPcTouchSetting();
@@ -1594,8 +1580,8 @@ void gamepadGenericReportStateToHost(void)
         {
             case GAMEPAD_TOUCH_MORE_BUTTONS_SETTING:
             {
-                gamepad->gpState.buttons &= ~(GAMEPAD_BUTTON_X | GAMEPAD_BUTTON_C | GAMEPAD_BUTTON_4
-                                              | GAMEPAD_BUTTON_5 | GAMEPAD_BUTTON_TL | GAMEPAD_BUTTON_TR);
+                gamepad->gpState.buttons &= ~(GAMEPAD_BUTTON_X | GAMEPAD_BUTTON_C | GAMEPAD_BUTTON_4 | GAMEPAD_BUTTON_5
+                                              | GAMEPAD_BUTTON_TL | GAMEPAD_BUTTON_TR);
                 if (!touched)
                 {
                     break;
@@ -1660,7 +1646,6 @@ void gamepadGenericReportStateToHost(void)
                 {
                     gamepad->gpState.x = x;
                     gamepad->gpState.y = y;
-                    //gamepad->gpState.z = z;
                 }
                 break;
             }
@@ -1668,17 +1653,15 @@ void gamepadGenericReportStateToHost(void)
             {
                 if (touched || getGamepadPcTouchStickRecenterSetting())
                 {
-                    gamepad->gpState.z = x;
-                    gamepad->gpState.rx = y;
-                    //gamepad->gpState.rx = z;
+                    gamepad->gpState.rx = x;
+                    gamepad->gpState.ry = y;
                 }
                 break;
             }
         }
-
         // Send the state over USB
         tud_hid_gamepad_report(HID_ITF_PROTOCOL_NONE, gamepad->gpState.x, gamepad->gpState.y, gamepad->gpState.z,
-                               gamepad->gpState.rx, gamepad->gpState.ry, gamepad->gpState.rz, 0,
+                               gamepad->gpState.rz, gamepad->gpState.rx, gamepad->gpState.ry, gamepad->gpState.hat,
                                gamepad->gpState.buttons);
     }
 }

--- a/main/utils/hashMap.c
+++ b/main/utils/hashMap.c
@@ -118,7 +118,6 @@ static void hashCheckSize(hashMap_t* map)
             // Zero the new memory as realloc does not do it for us
             memset(newArray + map->size, 0, (size - map->size) * sizeof(hashBucket_t));
 
-            int moved = 0;
             // Rehash everything in the old portion of the array
             for (int i = 0; i < map->size; i++)
             {
@@ -137,7 +136,6 @@ static void hashCheckSize(hashMap_t* map)
                             // The node belongs in a different bucket after the resize
                             hashNode_t tmp = bucketRemove(map, bucket, node, listNode, NULL);
                             node = bucketPut(map, &newArray[tmp.hash % size], tmp.key, tmp.value, tmp.hash, NULL);
-                            moved++;
                         }
                     }
                 }
@@ -149,7 +147,6 @@ static void hashCheckSize(hashMap_t* map)
                         // The node belongs in a different bucket after the resize
                         hashNode_t tmp = bucketRemove(map, bucket, node, NULL, NULL);
                         node           = bucketPut(map, &newArray[tmp.hash % size], tmp.key, tmp.value, tmp.hash, NULL);
-                        moved++;
                     }
                 }
             }
@@ -200,7 +197,6 @@ static hashNode_t* hashFindNode(hashMap_t* map, const void* key, uint32_t* hashO
         node = &bucket->single;
     }
 
-    int tries = 1;
     if (node->key != NULL && (node->hash != hash || !eqFn(node->key, key)))
     {
         // Node doesn't match!
@@ -210,7 +206,6 @@ static hashNode_t* hashFindNode(hashMap_t* map, const void* key, uint32_t* hashO
         {
             for (node_t* listNode = bucket->multi.first; listNode != NULL; listNode = listNode->next)
             {
-                tries++;
                 hashNode_t* newNode = listNode->val;
                 if (newNode->hash == hash && eqFn(newNode->key, key))
                 {
@@ -288,7 +283,6 @@ static hashNode_t* bucketPut(hashMap_t* map, hashBucket_t* bucket, const void* k
     // (It could still have only 1 entry but that's fine)
     hashNode_t* node = bucket->hasMulti ? (hashNode_t*)bucket->multi.first->val : &bucket->single;
 
-    int tries = 1;
     if (node->key != NULL && (node->hash != hash || !eqFn(node->key, key)))
     {
         // Node is non-empty and doesn't match hash
@@ -338,7 +332,6 @@ static hashNode_t* bucketPut(hashMap_t* map, hashBucket_t* bucket, const void* k
             node = NULL;
             for (node_t* listNode = bucket->multi.first; listNode != NULL; listNode = listNode->next)
             {
-                tries++;
                 newNode = listNode->val;
                 if (newNode->hash == hash && eqFn(newNode->key, key))
                 {

--- a/makefile
+++ b/makefile
@@ -343,8 +343,7 @@ endif
 ifeq ($(HOST_OS),Linux)
 LIBRARY_FLAGS += \
 	$(CFLAGS_SANITIZE) \
-	-fno-omit-frame-pointer \
-	-static-libasan
+	-fno-omit-frame-pointer
 ifeq ($(ENABLE_GCOV),true)
     LIBRARY_FLAGS += -lgcov -fprofile-arcs -ftest-coverage
 endif

--- a/tools/assets_preprocessor/src/font_processor.c
+++ b/tools/assets_preprocessor/src/font_processor.c
@@ -105,7 +105,6 @@ bool process_font(processorInput_t* arg)
     int charStartX      = 0;
     int charEndX        = 0;
     bool isCountingChar = false;
-    char ch             = ' ';
     for (int x = 0; x < w; x++)
     {
         switch (0xFFFFFF & getPx(data, w, x, h - 1))
@@ -124,8 +123,6 @@ bool process_font(processorInput_t* arg)
                 {
                     appendCharToFile(fp, data, w, h, charStartX, charEndX);
                     charsWritten++;
-                    /* Increment the char (dbg) */
-                    ch++;
                 }
                 charStartX     = x + 1;
                 charEndX       = x + 1;


### PR DESCRIPTION
## Description

Fixed gamepad inputs, drawing to TFT & LEDs

## Test Instructions

Use Steam's controller input tester (Settings > Controller > Test Device Inputs). Test with:
* D-Pad as D-Pad
* D-Pad as Left Stick
* D-Pad as Right Stick
* Touchpad as More Buttons
* Touchpad as Left Stick
* Touchpad as Right Stick
* Accel On (maps to Right Stick)
* Accel Off

> [!WARNING]
> Due to remapping, it is possible to map multiple inputs to the same output (i.e. Left and Right sticks). This behavior is somewhat undefined, so don't test 'invalid' configs

## Ticket Links

#619

## Readiness Checklist

### Code Quality

- [x] I have run `make format` to format the changes
- [ ] I have compiled the firmware and the changes have no warnings
- [ ] I have compiled the emulator and the changes have no warnings
- [ ] I have run `make cppcheck` and checked that `cppcheck_result.txt` has no warnings for the changes
- [ ] I have added doxygen comments to any code used by more than one Swadge mode. This includes `/*! \file` comments with Design Philosophy, Usage, and Example sections for new headers.
- [ ] I have run `make docs` and checked that `doxy_warnings.txt` has no warnings for the new code

### Feature Usage

<!--- These aren't mandatory, especially for non-game tickets, but are strongly encouraged -->

- [ ] As much hardware input is used as reasonable (buttons, touchpad, IMU, microphone)
- [ ] As much hardware output is used as reasonable (screen, LEDs, speaker)
- [ ] [Trophy](https://adam.feinste.in/Super-2024-Swadge-FW/trophy_8h.html) support is integrated
- [ ] [SwadgePass](https://adam.feinste.in/Super-2024-Swadge-FW/swadgePass_8h.html) support is integrated