### PR TITLE
Removed extranious swadgepass data fields

### DIFF
--- a/main/utils/network/swadgePass.h
+++ b/main/utils/network/swadgePass.h
@@ -162,13 +162,9 @@ typedef struct __attribute__((packed)) swadgePassPacket
     uint8_t version;   ///< A version byte to differentiate packets per-year
     struct
     {
-        uint16_t highScore;
-    } cosCrunch;
-    struct
-    {
-        int8_t reactHs;
-        int8_t memHs;
-    } swadgeIt;
+        uint32_t packedProfile; // card select 0-3, fact0 4-7, fact1 8-11, fact2 12-15
+        uint32_t points;
+    } atrium;
     struct
     {
         uint16_t highScore;
@@ -177,17 +173,6 @@ typedef struct __attribute__((packed)) swadgePassPacket
     {
         swadgesonaCore_t core;
     } swadgesona;
-
-    struct
-    {
-        uint32_t packedProfile; // card select 0-3, fact0 4-7, fact1 8-11, fact2 12-15
-        uint32_t points;
-    } atrium;
-
-    struct
-    {
-        uint16_t highScore;
-    } megaPulseEx;
 } swadgePassPacket_t;
 
 /**


### PR DESCRIPTION
## Description

Removed old data fields from the swadgepass packet and prepped it since I need to use it.

## Test Instructions

Hasn't been tested, but it's just removal

## Ticket Links

None

## Readiness Checklist

### Code Quality

- [x] I have run `make format` to format the changes
- [x] I have compiled the firmware and the changes have no warnings
- [x] I have compiled the emulator and the changes have no warnings
- [ ] I have run `make cppcheck` and checked that `cppcheck_result.txt` has no warnings for the changes
- [ ] I have added doxygen comments to any code used by more than one Swadge mode. This includes `/*! \file` comments with Design Philosophy, Usage, and Example sections for new headers.
- [ ] I have run `make docs` and checked that `doxy_warnings.txt` has no warnings for the new code